### PR TITLE
fix: add missing enum values and decoders in server utils

### DIFF
--- a/server/node/utils.cjs
+++ b/server/node/utils.cjs
@@ -18,6 +18,9 @@ const RisuSaveType = {
     REMOTE: 6,
     CHARACTER_WITHOUT_CHAT: 7,
     ROOT_COMPONENT: 8,
+    PLUGINS: 9,
+    LOADOUTS: 10,
+    PLUGIN_STORAGE: 11,
 };
 
 // Packr/Unpackr instances
@@ -254,6 +257,18 @@ class RisuSaveDecoder {
                 case RisuSaveType.ROOT_COMPONENT: {
                     const componentData = JSON.parse(this.blocks[key].content);
                     db[componentData.key] = componentData.data;
+                    break;
+                }
+                case RisuSaveType.PLUGINS: {
+                    db.plugins = JSON.parse(this.blocks[key].content);
+                    break;
+                }
+                case RisuSaveType.LOADOUTS: {
+                    db.loadouts = JSON.parse(this.blocks[key].content);
+                    break;
+                }
+                case RisuSaveType.PLUGIN_STORAGE: {
+                    db.pluginCustomStorage = JSON.parse(this.blocks[key].content);
                     break;
                 }
                 case RisuSaveType.REMOTE: {


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [ ] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

add missing PLUGINS/LOADOUTS/PLUGIN_STORAGE enum values and decoders in server utils for fix hash mismatch

## Related Issues

None

## Changes

Server-side RisuSaveType was missing PLUGINS=9, LOADOUTS=10, PLUGIN_STORAGE=11, so added

## Impact

None?

## Additional Notes

None