### PR TITLE
feat: Persistent swipe history, improved swipe UI, and branch comment preservation

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -41,11 +41,12 @@
         img?: string|Promise<string>;
         idx?: number;
         messageGenerationInfo?: MessageGenerationInfo|null;
-        rerollIcon?: boolean|'dynamic';
+        rerollIcon?: boolean|'dynamic'|'force';
         role?: string;
         totalLength?: number;
         onReroll?: () => void;
         unReroll?: () => void;
+        onDeleteSwipe?: () => void;
         character?: simpleCharacterArgument|string|null;
         firstMessage?: boolean;
         altGreeting?: boolean;
@@ -68,6 +69,7 @@
         totalLength = 0,
         onReroll = () => {},
         unReroll = () => {},
+        onDeleteSwipe = () => {},
         character = null,
         firstMessage = false,
         altGreeting = false,
@@ -763,19 +765,41 @@
 {/snippet}
 
 {#snippet rerolls()}
-    {#if rerollIcon || altGreeting}
-        {#if DBState.db.swipe || altGreeting}
-            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={unReroll}>
+    {#if (rerollIcon || altGreeting) && role !== 'user'}
+        {#if altGreeting}
+            <!-- First message: always ← counter → -->
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" onclick={unReroll}>
                 <ArrowLeft size={22}/>
             </button>
-            {#if firstMessage && DBState.db.swipe && DBState.db.showFirstMessagePages}
+            {#if DBState.db.showFirstMessagePages}
                 <span class="flex items-center text-xs text-textcolor2">{currentPage}/{totalPages}</span>
             {/if}
-            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={onReroll}>
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" onclick={onReroll}>
                 <ArrowRight size={22}/>
             </button>
+        {:else if DBState.db.swipe}
+            <!-- Normal messages: ← counter ↻/→ with hide/show logic -->
+            {#if currentPage <= 1}
+                <div class:dyna-icon={rerollIcon === 'dynamic'} class:force-show={rerollIcon === 'force'} style="width:22px"></div>
+            {:else}
+                <button class="flex items-center hover:text-blue-500 transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} onclick={unReroll}>
+                    <ArrowLeft size={22}/>
+                </button>
+            {/if}
+            {#if totalPages > 1}
+                <span class="flex items-center text-xs text-textcolor2" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'}>{currentPage}/{totalPages}</span>
+            {/if}
+            {#if currentPage >= totalPages}
+                <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} onclick={onReroll}>
+                    <RefreshCcwIcon size={22}/>
+                </button>
+            {:else}
+                <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} onclick={onReroll}>
+                    <ArrowRight size={22}/>
+                </button>
+            {/if}
         {:else}
-            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic'} onclick={onReroll}>
+            <button class="flex items-center hover:text-blue-500 transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} onclick={onReroll}>
                 <RefreshCcwIcon size={20}/>
             </button>
         {/if}
@@ -796,10 +820,22 @@
         </button>
     {/if}
 
+    {#if totalPages > 1}
+        <button class="flex items-center hover:text-red-500 transition-colors" onclick={async () => {
+            await sleep(1)
+            onDeleteSwipe()
+        }}>
+            <TrashIcon size={20}/>
+            {#if showNames}
+                <span class="ml-1">Delete Swipe ({currentPage}/{totalPages})</span>
+            {/if}
+        </button>
+    {/if}
+
     <button class="flex items-center hover:text-blue-500 transition-colors" onclick={async () => {
         await sleep(1)
         const currentChat = DBState.db.characters[selIdState.selId].chats[DBState.db.characters[selIdState.selId].chatPage]
-        
+
         if(DBState.db.createFolderOnBranch && !currentChat.folderId){
             const folderId = v4()
             DBState.db.characters[selIdState.selId].chatFolders ??= []

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -20,6 +20,7 @@
         currentCharacter,
         onReroll,
         unReroll,
+        onDeleteSwipe = () => {},
         currentUsername,
         userIcon,
         loadPages,
@@ -30,6 +31,7 @@
         currentCharacter: character | groupChat
         onReroll: () => void
         unReroll: () => void
+        onDeleteSwipe?: () => void
         currentUsername: string
         userIcon: string
         loadPages: number
@@ -64,6 +66,20 @@
         let loadStart = messages.length - 1
         let loadEnd = messages.length - loadPages
 
+        // Find the last real (non-comment, non-disabled) char message index
+        // Only show reroll if it's the actual last non-disabled message
+        let lastRealCharIdx = -1;
+        let lastNonDisabledIdx = -1;
+        for (let i = messages.length - 1; i >= 0; i--) {
+            if (!messages[i].isComment && !messages[i].disabled) {
+                lastNonDisabledIdx = i;
+                break;
+            }
+        }
+        if (lastNonDisabledIdx >= 0 && messages[lastNonDisabledIdx].role === 'char') {
+            lastRealCharIdx = lastNonDisabledIdx;
+        }
+
         if(chatFoldedStateMessageIndex.index !== -1){
             loadStart = chatFoldedStateMessageIndex.index
             loadEnd = Math.max(0, chatFoldedStateMessageIndex.index - loadPages)
@@ -76,13 +92,16 @@
             const message = messages[i];
             const messageLargePortrait = message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false);
             const reloadPointer = reloadPointerMap[i] ?? 0;
-            let hashd = message.data + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + reloadPointer.toString();
+            const isRerollTarget = i === lastRealCharIdx;
+            let hashd = message.data + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + reloadPointer.toString() + (message.swipeId ?? 0).toString() + (message.swipes?.length ?? 0).toString() + isRerollTarget.toString();
             const currentHash = hashCode(hashd);
             currentHashes.add(currentHash);
             if(!hashes.has(currentHash)){
                 const b = document.createElement('div');
                 b.setAttribute('x-hashed', currentHash.toString());
                 b.classList.add('chat-message-container');
+                const swipes = message.swipes;
+                const swipeId = message.swipeId ?? 0;
                 const inst = mount(Chat, {
                     target: b,
                     props: {
@@ -93,7 +112,8 @@
                         img: message.role === 'user' ? userImage : charImage,
                         onReroll: onReroll,
                         unReroll: unReroll,
-                        rerollIcon: 'dynamic',
+                        onDeleteSwipe: i === lastRealCharIdx ? onDeleteSwipe : () => {},
+                        rerollIcon: i === lastRealCharIdx ? 'force' : false,
                         character: simpleChar,
                         largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false),
                         messageGenerationInfo: message.generationInfo,
@@ -101,6 +121,10 @@
                         name: message.role === 'user' ? currentUsername : currentCharacter.name,
                         isComment: message.isComment ?? false,
                         disabled: message.disabled ?? false,
+                        ...(i === lastRealCharIdx && swipes && swipes.length > 0 ? {
+                            currentPage: swipeId + 1,
+                            totalPages: swipes.length,
+                        } : {}),
                     },
 
                 })

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -22,7 +22,6 @@
     import { aiLawApplies, chatFoldedState, chatFoldedStateMessageIndex, downloadFile } from 'src/ts/globalApi.svelte';
     import { runTrigger } from 'src/ts/process/triggers';
     import { v4 } from 'uuid';
-    import { PreUnreroll, Prereroll } from 'src/ts/process/prereroll';
     import { processMultiCommand } from 'src/ts/process/command';
     import { postChatFile } from 'src/ts/process/files/multisend';
     import { getInlayAsset } from 'src/ts/process/files/inlays';
@@ -45,9 +44,6 @@
     let messageInputTranslate:string = $state('')
     let openMenu = $state(false)
     let loadPages = $state(30)
-    let rerolls:Message[][] = []
-    let rerollid = -1
-    let lastCharId = -1
     let doingChatInputTranslate = false
     let toggleStickers:boolean = $state(false)
     let fileInput:string[] = $state([])
@@ -145,10 +141,6 @@
         if($doingChat){
             return
         }
-        if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
-        }
 
         let cha = DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message
 
@@ -207,96 +199,112 @@
         messageInput = ''
         messageInputTranslate = ''
         DBState.db.characters[selectedChar].chats[DBState.db.characters[selectedChar].chatPage].message = cha
-        rerolls = []
+
         await sleep(10)
         updateInputSizeAll()
         await sendChatMain(continueResponse)
 
     }
 
+    function getLastCharMsg() {
+        const msgs = DBState.db.characters[$selectedCharID]?.chats[DBState.db.characters[$selectedCharID].chatPage]?.message
+        if (!msgs || msgs.length === 0) return null
+        for (let i = msgs.length - 1; i >= 0; i--) {
+            if (msgs[i].role === 'char' && !msgs[i].isComment && !msgs[i].disabled) return msgs[i]
+        }
+        return null
+    }
+
     async function reroll() {
-        if($doingChat){
+        if($doingChat) return
+        const lastMsg = getLastCharMsg()
+        if (!lastMsg) return
+
+        // If swipes exist and not at the end, navigate forward
+        if (lastMsg.swipes && lastMsg.swipeId < lastMsg.swipes.length - 1) {
+            lastMsg.swipeId += 1
+            lastMsg.data = lastMsg.swipes[lastMsg.swipeId]
+            DBState.db.characters[$selectedCharID].reloadKeys += 1
             return
         }
-        if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
+
+        // Initialize swipes before generation
+        if (!lastMsg.swipes) {
+            lastMsg.swipes = [lastMsg.data]
+            lastMsg.swipeId = 0
         }
-        const genId = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)?.generationInfo?.generationId
-        if(genId){
-            const r = Prereroll(genId)
-            if(r){
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - 1].data = r
-                return
-            }
-        }
-        if(rerollid < rerolls.length - 1){
-            if(Array.isArray(rerolls[rerollid + 1])){
-                rerollid += 1
-                let rerollData = safeStructuredClone(rerolls[rerollid])
-                let msgs = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-                for(let i = 0; i < rerollData.length; i++){
-                    msgs[msgs.length - rerollData.length + i] = rerollData[i]
-                }
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = msgs
-            }
-            return
-        }
-        if(rerolls.length === 0){
-            rerolls.push(safeStructuredClone([DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)]))
-            rerollid = rerolls.length - 1
-        }
+
+        // At the end — generate new response
+        // Preserve trailing comment/disabled messages (e.g. branch comments)
         let cha = safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message)
-        if(cha.length === 0 ){
-            return
-        }
+        if(cha.length === 0) return
         openMenu = false
+
+        const trailingComments = []
+        while(cha.length > 0 && (cha[cha.length - 1].isComment || cha[cha.length - 1].disabled)) {
+            trailingComments.unshift(cha.pop())
+        }
+
+        if(cha.length === 0) return
         const saying = cha[cha.length - 1].saying
         let sayingQu = 2
         while(cha[cha.length - 1].role !== 'user'){
             if(cha[cha.length - 1].saying === saying){
                 sayingQu -= 1
-                if(sayingQu === 0){
-                    break
-                }
+                if(sayingQu === 0) break
             }
             let msg = cha.pop()
-            if(!msg){
-                return
-            }
+            if(!msg) return
         }
         DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = cha
         await sendChatMain()
+
+        // Restore trailing comments after the new message
+        if (trailingComments.length > 0) {
+            const msgs = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
+            msgs.push(...trailingComments)
+            DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = msgs
+        }
+
+        // After generation, save new response to swipes
+        const newLastMsg = getLastCharMsg()
+        if (newLastMsg && lastMsg.swipes) {
+            if (!newLastMsg.swipes) {
+                newLastMsg.swipes = [...lastMsg.swipes, newLastMsg.data]
+                newLastMsg.swipeId = newLastMsg.swipes.length - 1
+            }
+        }
     }
 
     async function unReroll() {
-        if($doingChat){
-            return
+        if($doingChat) return
+        const lastMsg = getLastCharMsg()
+        if (!lastMsg) return
+
+        if (!lastMsg.swipes || lastMsg.swipeId === undefined || lastMsg.swipeId <= 0) return
+
+        lastMsg.swipeId -= 1
+        lastMsg.data = lastMsg.swipes[lastMsg.swipeId]
+        DBState.db.characters[$selectedCharID].reloadKeys += 1
+    }
+
+    function deleteSwipe() {
+        const lastMsg = getLastCharMsg()
+        if (!lastMsg || !lastMsg.swipes || lastMsg.swipes.length <= 1) return
+
+        const idx = lastMsg.swipeId ?? 0
+        lastMsg.swipes.splice(idx, 1)
+
+        if (idx >= lastMsg.swipes.length) {
+            lastMsg.swipeId = lastMsg.swipes.length - 1
         }
-        if(lastCharId !== $selectedCharID){
-            rerolls = []
-            rerollid = -1
+        lastMsg.data = lastMsg.swipes[lastMsg.swipeId]
+
+        if (lastMsg.swipes.length === 1) {
+            delete lastMsg.swipes
+            delete lastMsg.swipeId
         }
-        const genId = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.at(-1)?.generationInfo?.generationId
-        if(genId){
-            const r = PreUnreroll(genId)
-            if(r){
-                DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message[DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length - 1].data = r
-                return
-            }
-        }
-        if(rerollid <= 0){
-            return
-        }
-        if(Array.isArray(rerolls[rerollid - 1])){
-            rerollid -= 1
-            let rerollData = safeStructuredClone(rerolls[rerollid])
-            let msgs = DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message
-            for(let i = 0; i < rerollData.length; i++){
-                msgs[msgs.length - rerollData.length + i] = rerollData[i]
-            }
-            DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message = msgs
-        }
+        DBState.db.characters[$selectedCharID].reloadKeys += 1
     }
 
     let abortController:null|AbortController = null
@@ -311,15 +319,10 @@
                 signal:abortController.signal,
                 continue:continued
             })
-            if(previousLength < DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length){
-                rerolls.push(safeStructuredClone(DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message).slice(previousLength))
-                rerollid = rerolls.length - 1
-            }
         } catch (error) {
             console.error(error)
             alertError(error)
         }
-        lastCharId = $selectedCharID
         $doingChat = false
         if(DBState.db.playMessage){
             const audio = new Audio(sendSound);
@@ -795,6 +798,7 @@
                 messages={currentChat}
                 loadPages={loadPages}
                 onReroll={reroll}
+                onDeleteSwipe={deleteSwipe}
                 unReroll={unReroll}
                 currentCharacter={currentCharacter}
                 currentUsername={currentUsername}
@@ -813,7 +817,7 @@
                         role='char'
                         img={getCharImage(DBState.db.characters[$selectedCharID].image, 'css')}
                         idx={-1}
-                        altGreeting={DBState.db.characters[$selectedCharID].alternateGreetings.length > 0}
+                        altGreeting={DBState.db.characters[$selectedCharID].alternateGreetings.length > 0 && DBState.db.characters[$selectedCharID].chats[DBState.db.characters[$selectedCharID].chatPage].message.length === 0}
                         largePortrait={DBState.db.characters[$selectedCharID].largePortrait}
                         firstMessage={true}
                         onReroll={() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -543,7 +543,8 @@ body {
   display: none;
 }
 
-.chat-message-container:first-of-type .dyna-icon {
+.chat-message-container:first-of-type .dyna-icon,
+.chat-message-container .dyna-icon.force-show {
   display: block;
 }
 

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -1949,6 +1949,8 @@ export interface Message{
     otherUser?:boolean
     disabled?:false|true|'allBefore'
     isComment?:boolean
+    swipes?: string[]
+    swipeId?: number
 }
 
 export interface MessageGenerationInfo{


### PR DESCRIPTION
## Summary

Improvements to the reroll (swipe) system — persistent history, better UI, and branch compatibility.

## Changes

### 1. Persistent Swipe History
- **Before:** Reroll history stored in memory only — lost on refresh or character switch
- **After:** Added `swipes: string[]` and `swipeId: number` to `Message` interface, saved to DB
- Reroll/unreroll now operates on `message.swipes[]`
- Removed in-memory `rerolls[]`/`rerollid` variables and `Prereroll`/`PreUnreroll` imports
- Fully backward-compatible — messages without `swipes` work as before
- `swipes` array is never included in API requests (only current `data` is used)

### 2. Swipe UI Improvements
**Normal messages:**
- First swipe (1/N): `[   ] [↻]` — left arrow hidden, reroll icon
- Middle (X/N): `[←] [X/N] [→]` — both arrows + page counter
- Last swipe (N/N): `[←] [N/N] [↻]` — left arrow + reroll icon
- User messages: no reroll UI (`role !== 'user'` check)

**First message (alternate greeting):**
- Always `[←] [→]`, page counter follows `showFirstMessagePages` setting

### 3. Individual Swipe Deletion
- "Delete Swipe (X/N)" button in hamburger menu (visible only when swipes ≥ 2)
- Deletes only the currently viewed swipe
- When only 1 swipe remains, `swipes`/`swipeId` fields are removed from message

### 4. First Message Greeting Lock
- Alternate greeting switching disabled when chat has ≥ 1 message
- Added `message.length === 0` condition to `altGreeting` prop

### 5. Branch Comment Preservation
- **Before:** Rerolling after a branch deleted the "branched from" comment via `cha.pop()`
- **After:** Trailing comment/disabled messages are preserved and restored after generation

### 6. Reroll UI Activation Scope
- Swipe navigation and deletion only activate on the last non-comment, non-disabled `char` message (`lastRealCharIdx`)
- If a user message is last → no reroll UI
- If a branch comment is last → reroll UI shows on the actual AI message above it (`force-show` CSS)

## Modified Files
| File | Change |
|---|---|
| `src/ts/storage/database.svelte.ts` | `swipes`, `swipeId` added to `Message` interface |
| `src/lib/ChatScreens/DefaultChatScreen.svelte` | `reroll()`/`unReroll()`/`deleteSwipe()` rewritten with swipes, trailing comment preservation |
| `src/lib/ChatScreens/Chat.svelte` | Swipe UI split (altGreeting vs normal), delete swipe button, `onDeleteSwipe` prop, `force` rerollIcon type |
| `src/lib/ChatScreens/Chats.svelte` | `lastRealCharIdx` calculation, swipe info + `onDeleteSwipe` passed to Chat, hash includes swipe state |
| `src/styles.css` | `.dyna-icon.force-show` rule for branch comment compatibility |

## Compatibility
- Fully backward-compatible with existing chat data
- No migration needed — messages without `swipes` field work unchanged
- No impact on API requests — only `message.data` (current swipe) is sent

Resolves #9