### PR TITLE
fix: verify manifest after push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -121,7 +121,11 @@ jobs:
           fi
           docker buildx imagetools create $TAGS \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
+      - name: Verify manifest
+        if: steps.version.outputs.is_tag == 'true'
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
   cleanup-old-images:
     needs: merge
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## PR Checklist
- Required Checks
    - [ ] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?

## Summary

Adds a post-push manifest verification step to the Docker publish workflow.

## Related Issues

None (prompted by the v1.2 broken publish — `linux/amd64` manifest returned HTTP 404 on GHCR despite the workflow succeeding)

## Changes

Added `Verify manifest` step in the `merge` job after `Create manifest list and push`. Runs `docker buildx imagetools inspect` on the published tag, which resolves every platform digest in the index and exits non-zero if any is missing. Skipped for non-tag builds.

## Impact

No impact on existing functionality. Future broken publishes will fail the workflow instead of silently reaching users.