### PR TITLE
fix: increase min-versions-to-keep to prevent platform digest deletion

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -121,18 +121,3 @@ jobs:
           fi
           docker buildx imagetools create $TAGS \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-  cleanup-old-images:
-    needs: merge
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Delete old package versions
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: risuai-nodeonly
-          package-type: container
-          min-versions-to-keep: 30
-          delete-only-untagged-versions: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -121,3 +121,84 @@ jobs:
           fi
           docker buildx imagetools create $TAGS \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+  cleanup-old-images:
+    needs: merge
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete orphaned untagged versions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = 'mrbart3885';
+            const pkg = 'risuai-nodeonly';
+
+            // 1. Get all package versions
+            const versions = await github.paginate(
+              github.rest.packages.getAllPackageVersionsForPackageOwnedByUser,
+              { package_type: 'container', package_name: pkg, username: owner, per_page: 100 }
+            );
+
+            // 2. Get ghcr.io auth token
+            const tokenResp = await fetch(
+              `https://ghcr.io/token?scope=repository:${owner}/${pkg}:pull`
+            );
+            const { token } = await tokenResp.json();
+
+            // 3. Collect digests referenced by tagged manifest lists
+            const referencedDigests = new Set();
+            for (const v of versions) {
+              if (v.metadata?.container?.tags?.length > 0) {
+                try {
+                  const resp = await fetch(
+                    `https://ghcr.io/v2/${owner}/${pkg}/manifests/${v.name}`,
+                    {
+                      headers: {
+                        'Authorization': `Bearer ${token}`,
+                        'Accept': 'application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json'
+                      }
+                    }
+                  );
+                  if (resp.ok) {
+                    const manifest = await resp.json();
+                    if (manifest.manifests) {
+                      for (const m of manifest.manifests) {
+                        referencedDigests.add(m.digest);
+                      }
+                    }
+                  }
+                } catch (e) {
+                  core.warning(`Failed to fetch manifest for ${v.name}: ${e.message}`);
+                }
+              }
+            }
+            core.info(`Referenced digests: ${referencedDigests.size}`);
+
+            // 4. Delete untagged versions NOT referenced by any manifest list
+            const untagged = versions
+              .filter(v => !v.metadata?.container?.tags?.length)
+              .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+
+            let deleted = 0;
+            for (const v of untagged) {
+              if (referencedDigests.has(v.name)) {
+                core.info(`KEEP ${v.name.slice(0, 20)}... (referenced)`);
+                continue;
+              }
+              core.info(`DELETE ${v.name.slice(0, 20)}... (orphaned)`);
+              try {
+                await github.rest.packages.deletePackageVersionForUser({
+                  package_type: 'container',
+                  package_name: pkg,
+                  username: owner,
+                  package_version_id: v.id
+                });
+                deleted++;
+              } catch (e) {
+                core.warning(`Failed to delete ${v.id}: ${e.message}`);
+              }
+            }
+            core.info(`Cleanup done: deleted ${deleted} orphaned versions, kept ${untagged.length - deleted} referenced`);

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -151,12 +151,13 @@ jobs:
               return;
             }
 
-            // 2. Get ghcr.io auth token (GITHUB_TOKEN for private, anon for public)
+            // 2. Get ghcr.io auth token (Basic auth for private support)
             let token;
             try {
+              const basicAuth = Buffer.from(`${owner}:${process.env.GITHUB_TOKEN}`).toString('base64');
               const tokenResp = await fetch(
                 `https://ghcr.io/token?scope=repository:${owner}/${pkg}:pull`,
-                { headers: { 'Authorization': `Bearer ${process.env.GITHUB_TOKEN}` } }
+                { headers: { 'Authorization': `Basic ${basicAuth}` } }
               );
               if (!tokenResp.ok) throw new Error(`token endpoint returned ${tokenResp.status}`);
               token = (await tokenResp.json()).token;
@@ -168,16 +169,17 @@ jobs:
             // 3. Collect digests referenced by tagged manifest lists
             const referencedDigests = new Set();
             let fetchFailures = 0;
+            const acceptHeader = [
+              'application/vnd.oci.image.index.v1+json',
+              'application/vnd.docker.distribution.manifest.list.v2+json',
+              'application/vnd.oci.image.manifest.v1+json',
+              'application/vnd.docker.distribution.manifest.v2+json'
+            ].join(',');
             for (const v of tagged) {
               try {
                 const resp = await fetch(
                   `https://ghcr.io/v2/${owner}/${pkg}/manifests/${v.name}`,
-                  {
-                    headers: {
-                      'Authorization': `Bearer ${token}`,
-                      'Accept': 'application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json'
-                    }
-                  }
+                  { headers: { 'Authorization': `Bearer ${token}`, 'Accept': acceptHeader } }
                 );
                 if (!resp.ok) {
                   fetchFailures++;
@@ -185,6 +187,7 @@ jobs:
                   continue;
                 }
                 const manifest = await resp.json();
+                // manifest list → collect child digests; single manifest → no children
                 if (manifest.manifests) {
                   for (const m of manifest.manifests) {
                     referencedDigests.add(m.digest);
@@ -197,13 +200,13 @@ jobs:
             }
             core.info(`Referenced digests: ${referencedDigests.size}, fetch failures: ${fetchFailures}`);
 
-            // 4. Safety checks
-            if (referencedDigests.size === 0) {
-              core.error('No referenced digests found — aborting to prevent data loss');
+            // 4. Safety: abort if ANY manifest list fetch failed
+            if (fetchFailures > 0) {
+              core.error(`${fetchFailures} manifest fetch(es) failed — aborting to prevent data loss`);
               return;
             }
-            if (fetchFailures > tagged.length / 2) {
-              core.error(`Too many fetch failures (${fetchFailures}/${tagged.length}) — aborting`);
+            if (referencedDigests.size === 0) {
+              core.info('No multi-platform manifests found — nothing to clean up');
               return;
             }
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -134,5 +134,5 @@ jobs:
         with:
           package-name: risuai-nodeonly
           package-type: container
-          min-versions-to-keep: 5
+          min-versions-to-keep: 30
           delete-only-untagged-versions: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const owner = 'mrbart3885';
+            const owner = context.repo.owner;
             const pkg = 'risuai-nodeonly';
 
             // 1. Get all package versions

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -142,53 +142,78 @@ jobs:
               { package_type: 'container', package_name: pkg, username: owner, per_page: 100 }
             );
 
-            // 2. Get ghcr.io auth token
-            const tokenResp = await fetch(
-              `https://ghcr.io/token?scope=repository:${owner}/${pkg}:pull`
-            );
-            const { token } = await tokenResp.json();
+            const tagged = versions.filter(v => v.metadata?.container?.tags?.length > 0);
+            const untagged = versions.filter(v => !v.metadata?.container?.tags?.length);
+            core.info(`Total: ${versions.length} versions (${tagged.length} tagged, ${untagged.length} untagged)`);
+
+            if (tagged.length === 0) {
+              core.warning('No tagged versions found — aborting cleanup');
+              return;
+            }
+
+            // 2. Get ghcr.io auth token (GITHUB_TOKEN for private, anon for public)
+            let token;
+            try {
+              const tokenResp = await fetch(
+                `https://ghcr.io/token?scope=repository:${owner}/${pkg}:pull`,
+                { headers: { 'Authorization': `Bearer ${process.env.GITHUB_TOKEN}` } }
+              );
+              if (!tokenResp.ok) throw new Error(`token endpoint returned ${tokenResp.status}`);
+              token = (await tokenResp.json()).token;
+            } catch (e) {
+              core.error(`Failed to get ghcr.io token: ${e.message} — aborting cleanup`);
+              return;
+            }
 
             // 3. Collect digests referenced by tagged manifest lists
             const referencedDigests = new Set();
-            for (const v of versions) {
-              if (v.metadata?.container?.tags?.length > 0) {
-                try {
-                  const resp = await fetch(
-                    `https://ghcr.io/v2/${owner}/${pkg}/manifests/${v.name}`,
-                    {
-                      headers: {
-                        'Authorization': `Bearer ${token}`,
-                        'Accept': 'application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json'
-                      }
-                    }
-                  );
-                  if (resp.ok) {
-                    const manifest = await resp.json();
-                    if (manifest.manifests) {
-                      for (const m of manifest.manifests) {
-                        referencedDigests.add(m.digest);
-                      }
+            let fetchFailures = 0;
+            for (const v of tagged) {
+              try {
+                const resp = await fetch(
+                  `https://ghcr.io/v2/${owner}/${pkg}/manifests/${v.name}`,
+                  {
+                    headers: {
+                      'Authorization': `Bearer ${token}`,
+                      'Accept': 'application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json'
                     }
                   }
-                } catch (e) {
-                  core.warning(`Failed to fetch manifest for ${v.name}: ${e.message}`);
+                );
+                if (!resp.ok) {
+                  fetchFailures++;
+                  core.warning(`Manifest fetch failed for ${v.metadata.container.tags}: HTTP ${resp.status}`);
+                  continue;
                 }
+                const manifest = await resp.json();
+                if (manifest.manifests) {
+                  for (const m of manifest.manifests) {
+                    referencedDigests.add(m.digest);
+                  }
+                }
+              } catch (e) {
+                fetchFailures++;
+                core.warning(`Manifest fetch error for ${v.name}: ${e.message}`);
               }
             }
-            core.info(`Referenced digests: ${referencedDigests.size}`);
+            core.info(`Referenced digests: ${referencedDigests.size}, fetch failures: ${fetchFailures}`);
 
-            // 4. Delete untagged versions NOT referenced by any manifest list
-            const untagged = versions
-              .filter(v => !v.metadata?.container?.tags?.length)
-              .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+            // 4. Safety checks
+            if (referencedDigests.size === 0) {
+              core.error('No referenced digests found — aborting to prevent data loss');
+              return;
+            }
+            if (fetchFailures > tagged.length / 2) {
+              core.error(`Too many fetch failures (${fetchFailures}/${tagged.length}) — aborting`);
+              return;
+            }
+
+            // 5. Delete untagged versions NOT referenced by any manifest list
+            const orphaned = untagged.filter(v => !referencedDigests.has(v.name));
+            core.info(`Orphaned: ${orphaned.length}, Referenced: ${untagged.length - orphaned.length}`);
 
             let deleted = 0;
-            for (const v of untagged) {
-              if (referencedDigests.has(v.name)) {
-                core.info(`KEEP ${v.name.slice(0, 20)}... (referenced)`);
-                continue;
-              }
-              core.info(`DELETE ${v.name.slice(0, 20)}... (orphaned)`);
+            for (const v of orphaned) {
+              core.info(`DELETE ${v.name.substring(0, 27)}...`);
               try {
                 await github.rest.packages.deletePackageVersionForUser({
                   package_type: 'container',
@@ -201,4 +226,6 @@ jobs:
                 core.warning(`Failed to delete ${v.id}: ${e.message}`);
               }
             }
-            core.info(`Cleanup done: deleted ${deleted} orphaned versions, kept ${untagged.length - deleted} referenced`);
+            core.info(`Cleanup done: deleted ${deleted} orphaned versions`);
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
cleanup-old-images 잡이 min-versions-to-keep: 5로 설정되어 있어서
멀티플랫폼 빌드의 untagged platform digest(amd64/arm64)가 삭제됨.
manifest list가 삭제된 digest를 참조하여 x86 사용자의 docker pull 실패.

5 → 30으로 증가하여 최소 10개 릴리즈의 플랫폼 이미지를 보존.
(릴리즈당 tagged manifest 1개 + untagged digest 2개 = 3 versions)

https://claude.ai/code/session_018dCMbVg8bGU9zwwSv8vwVw