### PR TITLE
chore: bump Actions versions and make Docker workflow portable

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -64,7 +64,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ steps.slug.outputs.pair }}
           path: /tmp/digests/*
@@ -84,7 +84,7 @@ jobs:
         run: echo "image_name=${IMAGE_NAME,,}" >> $GITHUB_OUTPUT
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digest-*

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: mrbart3885/risuai-nodeonly
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -26,14 +26,18 @@ jobs:
       packages: write
 
     steps:
+      - name: Lowercase image name
+        id: lower
+        run: echo "image_name=${IMAGE_NAME,,}" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,11 +49,11 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.lower.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ steps.slug.outputs.pair }}
           cache-to: type=gha,scope=${{ steps.slug.outputs.pair }},mode=max
 
@@ -75,6 +79,10 @@ jobs:
       packages: write
 
     steps:
+      - name: Lowercase image name
+        id: lower
+        run: echo "image_name=${IMAGE_NAME,,}" >> $GITHUB_OUTPUT
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -83,10 +91,10 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -111,16 +119,17 @@ jobs:
         working-directory: /tmp/digests
         shell: bash
         run: |
+          IMAGE="${{ env.REGISTRY }}/${{ steps.lower.outputs.image_name }}"
           TAGS=""
           if [[ "${{ steps.version.outputs.is_tag }}" == "true" ]]; then
-            TAGS="-t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-            TAGS="$TAGS -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}"
-            TAGS="$TAGS -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.minor }}"
+            TAGS="-t ${IMAGE}:latest"
+            TAGS="$TAGS -t ${IMAGE}:v${{ steps.version.outputs.version }}"
+            TAGS="$TAGS -t ${IMAGE}:v${{ steps.version.outputs.minor }}"
           else
-            TAGS="-t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
+            TAGS="-t ${IMAGE}:${{ steps.version.outputs.version }}"
           fi
           docker buildx imagetools create $TAGS \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf "${IMAGE}@sha256:%s " *)
 
   cleanup-old-images:
     needs: merge
@@ -134,7 +143,7 @@ jobs:
         with:
           script: |
             const owner = context.repo.owner;
-            const pkg = 'risuai-nodeonly';
+            const pkg = context.repo.repo.toLowerCase();
 
             // 1. Get all package versions
             const versions = await github.paginate(


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

- Bump workflow actions versions
- Changed some hard-coded values into variables

## Related Issues

None

## Changes

- Bump workflow actions versions
  -  `actions/checkout` v4 → v6
  - `docker/setup-buildx-action` v3 → v4
  - `docker/login-action` v3 → v4
  - `docker/build-push-action` v5 → v7

It resolves [Node.js 20 deprecation warnings](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) that notifies users to use workflows actions that uses newer node24-based environment.

- Replace hardcoded `IMAGE_NAME` as `mrbart3885/risuai-nodeonly` with `${{ github.repository }}` + a lowercase step so the workflow works correctly on forks
- Derive cleanup job's package name dynamically via `context.repo.repo.toLowerCase()` instead of hardcoding `risuai-nodeonly`

## Impact

No breaking changes

## Additional Notes

This workflow has been tested and you can look at it [here](https://github.com/tasoo-oos/Risuai-NodeOnly/actions/runs/24442381337).