### PR TITLE
HypaMemory V3 embedding and summarization fail on remote access

### DIFF
--- a/src/ts/process/memory/hypamemory.ts
+++ b/src/ts/process/memory/hypamemory.ts
@@ -4,6 +4,7 @@ import { appendLastPath } from "src/ts/util";
 import { getDatabase } from "src/ts/storage/database.svelte";
 import { makeHashedStorageKey, readPersistentJson, writePersistentJson } from "src/ts/storage/persistentKv";
 import { isContextModel, getContextProvider } from "./contextualEmbedding";
+import { isLocalNetworkUrl } from "src/ts/network/localNetwork";
 
 export type HypaModel = 'custom'|'ada'|'openai3small'|'openai3large'|'MiniLM'|'MiniLMGPU'|'nomic'|'nomicGPU'|'bgeSmallEn'|'bgeSmallEnGPU'|'bgem3'|'bgem3GPU'|'multiMiniLM'|'multiMiniLMGPU'|'bgeM3Ko'|'bgeM3KoGPU'|'voyageContext3'
 
@@ -135,7 +136,8 @@ export class HypaProcesser{
                 }
             };
  
-            gf = await globalFetch(replaceUrl.toString(), fetchArgs)
+            const localNetworkOpts = isLocalNetworkUrl(replaceUrl.toString()) ? { networkRoute: 'local_network' as const } : {};
+            gf = await globalFetch(replaceUrl.toString(), { ...fetchArgs, ...localNetworkOpts })
         }
         if(this.model === 'ada' || this.model === 'openai3small' || this.model === 'openai3large'){
             const db = getDatabase()

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -15,6 +15,7 @@ import {
 } from "src/ts/storage/database.svelte";
 import { type OpenAIChat } from "../index.svelte";
 import { requestChatData } from "../request/request";
+import { isLocalNetworkUrl } from "src/ts/network/localNetwork";
 import { chatCompletion, unloadEngine } from "../webllm";
 import { hypaV3ProgressStore } from "src/ts/stores.svelte";
 import { type ChatTokenizer } from "src/ts/tokenizer";
@@ -1696,13 +1697,20 @@ export async function summarize(oaiMessages: OpenAIChat[], isResummarize: boolea
     if (settings.summarizationModel === "subModel") {
         console.log(logPrefix, `Using ax model ${db.subModel} for summarization.`);
 
+        let subModelUrl = '';
+        if (db.subModel === 'reverse_proxy') {
+            subModelUrl = db.forceReplaceUrl ?? '';
+        } else if (db.subModel?.startsWith('xcustom:::')) {
+            subModelUrl = db.customModels?.find(m => m.id === db.subModel)?.url ?? '';
+        }
+
         const response = await requestChatData(
             {
                 formated,
                 bias: {},
                 useStreaming: false,
                 noMultiGen: true,
-                forceLocalNetwork: true,
+                forceLocalNetwork: isLocalNetworkUrl(subModelUrl),
             },
             "memory"
         );

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -1702,6 +1702,7 @@ export async function summarize(oaiMessages: OpenAIChat[], isResummarize: boolea
                 bias: {},
                 useStreaming: false,
                 noMultiGen: true,
+                forceLocalNetwork: true,
             },
             "memory"
         );

--- a/src/ts/process/request/openAI/requests.ts
+++ b/src/ts/process/request/openAI/requests.ts
@@ -13,9 +13,9 @@ interface LocalNetworkRequestOptions {
     requestTimeoutMs?: number
 }
 
-function getLocalNetworkRequestOptions(url: string): LocalNetworkRequestOptions {
+function getLocalNetworkRequestOptions(url: string, force: boolean = false): LocalNetworkRequestOptions {
     const db = getDatabase()
-    if (!db.localNetworkMode) return {}
+    if (!force && !db.localNetworkMode) return {}
     if (!isLocalNetworkUrl(url)) return {}
     return {
         networkRoute: 'local_network' as const,
@@ -572,7 +572,7 @@ export async function requestOpenAI(arg:RequestDataArgumentExtended):Promise<req
             signal: arg.abortSignal,
             chatId: arg.chatId,
             interceptor: 'openai_streaming',
-            ...getLocalNetworkRequestOptions(replacerURL),
+            ...getLocalNetworkRequestOptions(replacerURL, arg.forceLocalNetwork),
         })
 
         if(da.status !== 200){
@@ -635,7 +635,7 @@ async function requestHTTPOpenAI(replacerURL:string,body:any, headers:Record<str
         abortSignal: arg.abortSignal,
         chatId: arg.chatId,
         interceptor: 'openai_basic',
-        ...getLocalNetworkRequestOptions(replacerURL),
+        ...getLocalNetworkRequestOptions(replacerURL, arg.forceLocalNetwork),
     })
 
     function processTextResponse(dat: any):string{

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -51,6 +51,7 @@ interface requestDataArgument{
     rememberToolUsage?: boolean
     forceStreaming?: boolean
     blockPlugins?: boolean
+    forceLocalNetwork?: boolean
 }
 
 export interface RequestDataArgumentExtended extends requestDataArgument{


### PR DESCRIPTION
## Summary

(먼저 빈약한 내용에 죄송하다는 말씀 전합니다. 공개 리포지토리에 Pull Request를 처음 넣어봅니다.)

HypaMemory V3의 채팅 요약 기능을 로컬 LLM을 통한 보조모델로 사용하는 이용자가
Tailscale 등을 통해 외부 기기에서 RisuAI NodeOnly에 원격 접속할 때 
HypaMemory V3의 **요약 생성**이 실패하는 문제를 수정합니다.

### 왜 실패하는가

제가 겪었던 케이스 중 하나인, 외부에서 접속하는 모바일 브라우저 입장에서 보겠습니다.

Risu NodeOnly는 호스트에서 서버를 띄우고, 모바일 브라우저가 그 서버에 접속해 사용합니다. 로컬 LLM(`127.0.0.1:8080`)으로의 일반 채팅 요청은 Risu 서버가 대신 처리해주기 때문에 모바일에서도 정상 동작합니다.

그러나 HypaMemory V3의 채팅 요약 요청은 **브라우저가 직접** 로컬 LLM 주소로 요청을 보내는 구조였습니다. 
모바일 브라우저 입장에서 `127.0.0.1`은 PC가 아닌 **모바일 기기 자신**을 가리키기 때문에 요청이 도달하지 못합니다. 또한 HTTPS 페이지에서 HTTP 주소로 직접 요청하는 것은 보안 정책상 브라우저가 차단합니다.

### 해결 방법

요청 주소가 내 PC 안의 주소(`127.0.0.1`, `localhost` 등)인 경우, 브라우저가 직접 요청하는 대신 **Risu 서버를 거쳐 중계**하도록 변경했습니다.

```
[수정 전] 모바일 브라우저 → 127.0.0.1:8080  ← 모바일 자신에게 보내는 꼴, 실패

[수정 후] 모바일 브라우저 → Risu 서버 → 127.0.0.1:8080  ← 서버가 대신 전달, 성공
```

## Related Issues

None.

## Changes

**`src/ts/process/memory/hypamemory.ts`** — 임베딩 요청 수정

커스텀 임베딩 서버 주소가 로컬 주소인 경우 서버 중계 경로를 사용하도록 변경합니다.

```ts
import { isLocalNetworkUrl } from "src/ts/network/localNetwork";

// 로컬 주소이면 서버 중계 옵션 추가, 외부 주소이면 그대로
const localNetworkOpts = isLocalNetworkUrl(replaceUrl.toString())
    ? { networkRoute: 'local_network' as const }
    : {};
gf = await globalFetch(replaceUrl.toString(), { ...fetchArgs, ...localNetworkOpts })
```

**`src/ts/process/request/request.ts`** — 요약 요청 수정 (1/3)

요청 데이터 구조에 "로컬 주소면 서버 중계를 강제할 것" 옵션을 추가합니다.

```ts
forceLocalNetwork?: boolean
```

**`src/ts/process/request/openAI/requests.ts`** — 요약 요청 수정 (2/3)

네트워크 경로를 결정하는 함수가 위 옵션을 받아 처리할 수 있도록 수정합니다.

```ts
function getLocalNetworkRequestOptions(url: string, force: boolean = false) {
    const db = getDatabase()
    if (!force && !db.localNetworkMode) return {}  // force가 true면 설정 무관하게 진행
    if (!isLocalNetworkUrl(url)) return {}          // 외부 주소면 여기서 중단, 변화 없음
    return { networkRoute: 'local_network', ... }
}
```

**`src/ts/process/memory/hypav3.ts`** — 요약 요청 수정 (3/3)

요약 요청 시 subModel 주소가 실제로 로컬 주소인 경우에만 서버 중계를 강제합니다. 외부 API를 사용하는 경우엔 이 옵션이 켜지지 않습니다.

```ts
import { isLocalNetworkUrl } from "src/ts/network/localNetwork";

// subModel 주소 파악
let subModelUrl = '';
if (db.subModel === 'reverse_proxy') {
    subModelUrl = db.forceReplaceUrl ?? '';
} else if (db.subModel?.startsWith('xcustom:::')) {
    subModelUrl = db.customModels?.find(m => m.id === db.subModel)?.url ?? '';
}

// 로컬 주소일 때만 서버 중계 강제
const response = await requestChatData(
    {
        formated,
        bias: {},
        useStreaming: false,
        noMultiGen: true,
        forceLocalNetwork: isLocalNetworkUrl(subModelUrl),
    },
    "memory"
);
```

## Impact

| 사용 환경 | 영향 |
|---|---|
| OpenAI, Claude 등 외부 API 사용자 | 없음 — 외부 주소는 조건을 만족하지 않아 기존과 동일하게 동작 |
| 로컬 LLM, PC에서 직접 접속 | 없음 — 서버가 같은 PC에 있으므로 중계해도 결과 동일 |
| 로컬 LLM, 모바일/원격 접속 | **수정됨** — 서버 중계로 정상 동작 |

## Additional Notes

- 임베딩과 요약 요청을 각각 차례로 수정했습니다. 임베딩이 정상 동작하더라도 요약 단계에서 동일한 원인으로 실패할 수 있음을 실사용 테스트로 확인하고 추후에 후속 수정했습니다.
- 이미 Risu 내부의 일반 LLM 요청(`getLocalNetworkRequestOptions`)에 존재하는 서버 중계 패턴을 HypaMemory V3에도 동일하게 적용한 것입니다.
- 외부 API 사용자 보호를 위해 "로컬 주소 여부(`isLocalNetworkUrl`)"를 반드시 확인한 뒤에만 중계 경로를 적용합니다.

## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    요청 데이터를 담는 구조체(`requestDataArgument`)에 `forceLocalNetwork`라는 선택적 항목을 추가했습니다.

    - [x] Have you tested your changes?
    Tailscale을 통한 모바일 원격 접속 환경에서 직접 테스트했습니다. 임베딩 요청 및 요약본 생성 모두 정상 동작을 확인했습니다.

    - [x] Have you checked that it won't break any existing features?
    수정된 경로는 "요청 주소가 내 PC 안에 있는 주소인가"를 먼저 확인합니다. OpenAI, Claude 등 외부 API 주소는 이 조건을 만족하지 않으므로 기존 사용자에게는 아무 영향이 없습니다.

- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
   **추후 모바일 브라우저에서 하이파 채팅 요약을 로컬 LLM 보조 모델로 설정하고도 정상 작동하는 것을 확인했습니다.
   연산자를 이용해 로컬 주소인지 확인하는 구문을 넣었을 터이지만 외부 API로 테스트 해보지 못하여 추가적인 확인은 못했습니다.**

- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    이 개선 작업은 **대부분 AI의 도움을 받았습니다.** 
   실제 사용자인 저는 다음을 이해하고 진행했습니다: 모바일 브라우저가 내 PC 안의 주소(`127.0.0.1`)로 직접 요청을 보내면, 모바일 입장에서 그 주소는 모바일 기기 자신을 가리키기 때문에 PC에 도달할 수 없습니다. 이 문제를 Risu 서버가 대신 중계하는 방식으로 해결 가능하다는 것만 알고 있습니다. 그 밖에는 AI에게 다른 외부 API를 사용하는 사람들은 문제가 없는 게 확실하냐며 닦달한 것이 다입니다.

    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
    총 4개 파일 수정, 추가된 코드는 20줄 미만의 최소한의 변경입니다.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.