### PR TITLE
fix(update): re-read package.json on every update check

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -795,12 +795,14 @@ const UPDATE_CHECK_DISABLED = process.env.RISU_UPDATE_CHECK === 'false';
 const UPDATE_CHECK_URL = process.env.RISU_UPDATE_URL || 'https://risu-update-worker.nodridan.workers.dev/check';
 const PUBLIC_STATS_URL = (process.env.RISU_UPDATE_URL || 'https://risu-update-worker.nodridan.workers.dev/check').replace(/\/check$/, '/api/public-stats');
 
-const currentVersion = (() => {
+// Re-read on each call so non-portable updates (docker/git pull) without a
+// process restart don't keep reporting the old version to the update worker.
+function getCurrentVersion() {
     try {
         const pkg = JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
         return pkg.version || '0.0.0';
     } catch { return '0.0.0'; }
-})();
+}
 
 // ── Deployment type & self-update helpers ─────────────────────────────────────
 const GITHUB_REPO = 'mrbart3885/Risuai-NodeOnly';
@@ -1166,6 +1168,7 @@ async function migrateInlaysToFilesystem() {
 async function fetchLatestRelease() {
     if (UPDATE_CHECK_DISABLED) return null;
     try {
+        const currentVersion = getCurrentVersion();
         const params = new URLSearchParams({
             v: currentVersion,
             d: deploymentType,
@@ -5210,6 +5213,7 @@ app.get('/api/public-stats', async (req, res) => {
 
 // ── Update check endpoint ────────────────────────────────────────────────────
 app.get('/api/update-check', async (req, res) => {
+    const currentVersion = getCurrentVersion();
     if (UPDATE_CHECK_DISABLED) {
         res.json({ currentVersion, hasUpdate: false, severity: 'none', disabled: true, deploymentType, canSelfUpdate: false });
         return;


### PR DESCRIPTION
## Summary

User report: after updating to v1.5.0, the home screen shows `📦 NodeOnly v1.5.0` at the top but a red banner below reads `v1.5.0 — 현재 버전이 너무 오래되었습니다`. The banner disappears after a manual server restart.

### Root cause

`server.cjs` captured the version into a module-level constant at process start:

```js
const currentVersion = (() => { ...readFileSync('package.json')... })();
```

This value is sent to the remote update worker as `?v=...` and echoed back in `/api/update-check`. When a non-portable install is updated by replacing files (docker pull, `git pull`, manual unzip) **without** restarting the Node process, the on-disk `package.json` is now `1.5.0` but the running process still reports the old version. The worker correctly classifies the old version as `outdated` (the v1.5.0 release notes carry `RISU_MIN_VERSION: 1.5.0`) and returns `latestVersion: "1.5.0"`. Meanwhile the freshly-built frontend bundle has `__APP_VERSION__ = "1.5.0"` baked in, so the title shows the new version while the banner shows the stale-server response — the contradiction the user saw.

The portable self-update path normally restarts the process so the const refreshes, but if the detached restart fails the same stale state is left behind.

### Fix

Replace the module-level const with a `getCurrentVersion()` helper that reads `package.json` on each call, and use it inside `fetchLatestRelease()` and the `/api/update-check` handler. The next poll after a file-replacement update now reports the correct version and the banner clears without a restart. Cost is one small sync read per update check (low frequency).

## Test plan

- [ ] Start server on an older version, replace `package.json` version field with the latest tag while the process is still running, hit `/api/update-check`, confirm response shows the new version and `hasUpdate: false`
- [ ] Confirm normal update flow (worker reachable, version actually behind) still produces the expected `hasUpdate: true` payload
- [ ] Confirm `RISU_UPDATE_CHECK=false` short-circuit still returns the current version in the payload
- [ ] Run portable self-update end-to-end and confirm banner clears on the new process without manual reload

https://claude.ai/code/session_012WPpgVJFtWWcEAT4nTWNFg

---
_Generated by [Claude Code](https://claude.ai/code/session_012WPpgVJFtWWcEAT4nTWNFg)_