### PR TITLE
fix(backup): stream NDJSON progress on import to dodge proxy 502

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -700,6 +700,17 @@ function shouldCompress(req, res) {
     if (contentType.includes('text/event-stream')) {
         return false;
     }
+    // NDJSON endpoints (backup import/restore, inlay bulk compression) emit
+    // small per-line events and rely on real-time flushes — keepalive
+    // heartbeats in particular must reach reverse proxies before their
+    // response timeout fires. gzip would buffer those lines until enough
+    // bytes accumulated for an efficient compression block, defeating the
+    // 502-avoidance the streaming endpoints were built for. compressible's
+    // mime-db happens not to list application/x-ndjson today (so this is
+    // a no-op in practice) but a future dep upgrade could flip it on.
+    if (contentType.includes('application/x-ndjson')) {
+        return false;
+    }
     // Already-compressed media formats: gzip adds CPU cost with ~0% size gain
     if (contentType.startsWith('image/') || contentType.startsWith('video/') || contentType.startsWith('audio/')) {
         return false;
@@ -799,6 +810,14 @@ const BACKUP_IMPORT_MAX_BYTES = Number(process.env.RISU_BACKUP_IMPORT_MAX_BYTES 
 const BACKUP_ENTRY_NAME_MAX_BYTES = 1024;
 // Minimum free disk space headroom multiplier: require 2× the backup size to be free
 const BACKUP_DISK_HEADROOM = 2;
+// Heartbeat interval for NDJSON import progress stream. 5 s by default —
+// shorter than every common reverse-proxy response timeout (nginx 60 s, Cloudflare
+// 100 s). Operators behind more aggressive proxies can tighten this. Clamped to
+// 100 ms so a misconfiguration can't spam the socket.
+const BACKUP_NDJSON_HEARTBEAT_MS = Math.max(
+    100,
+    Number(process.env.BACKUP_NDJSON_HEARTBEAT_MS ?? '5000') || 5000,
+);
 
 let importInProgress = false;
 
@@ -3823,6 +3842,13 @@ app.post('/api/backup/import', async (req, res, next) => {
     req.socket.setKeepAlive(true);
     if (req.socket.server) req.socket.server.requestTimeout = 0;
 
+    // NDJSON streaming keeps the response socket alive during long
+    // post-upload work (WAL checkpoint, cold-storage migration). Without it
+    // a reverse proxy in front of the server can hit its response timeout
+    // and bounce the request back to the client as 502 Bad Gateway.
+    const wantsNdjson = String(req.headers['accept'] ?? '').includes('application/x-ndjson');
+    let heartbeatTimer = null;
+
     try {
         const contentType = String(req.headers['content-type'] ?? '');
         if (contentType && !contentType.includes('application/x-risu-backup') && !contentType.includes('application/octet-stream')) {
@@ -3836,15 +3862,57 @@ app.post('/api/backup/import', async (req, res, next) => {
             return;
         }
 
-        const result = await importBackupFromSource(req, { maxBytes: BACKUP_IMPORT_MAX_BYTES });
-        res.json({
-            ok: true,
-            assetsRestored: result.assetsRestored,
-            coldStorageFailed: result.coldStorageFailed,
-        });
+        if (wantsNdjson) {
+            res.setHeader('content-type', 'application/x-ndjson');
+            res.setHeader('cache-control', 'no-cache, no-transform');
+            // Disable nginx response buffering so progress events flush immediately.
+            res.setHeader('x-accel-buffering', 'no');
+            res.flushHeaders();
+
+            // Periodic keepalive — covers the post-stream phase (commit,
+            // inlay dir swap, cold storage migration) where onProgress is silent.
+            heartbeatTimer = setInterval(() => {
+                if (!res.writableEnded) res.write('{"type":"heartbeat"}\n');
+            }, BACKUP_NDJSON_HEARTBEAT_MS);
+
+            let lastProgressWrite = 0;
+            const totalBytes = Number.isFinite(contentLength) ? contentLength : 0;
+            const result = await importBackupFromSource(req, {
+                maxBytes: BACKUP_IMPORT_MAX_BYTES,
+                totalBytes,
+                onProgress: (received, total) => {
+                    const now = Date.now();
+                    if (now - lastProgressWrite < 200) return;
+                    lastProgressWrite = now;
+                    res.write(JSON.stringify({ type: 'progress', bytes: received, totalBytes: total }) + '\n');
+                },
+            });
+            res.write(JSON.stringify({
+                type: 'done',
+                ok: true,
+                assetsRestored: result.assetsRestored,
+                coldStorageFailed: result.coldStorageFailed,
+            }) + '\n');
+            res.end();
+        } else {
+            const result = await importBackupFromSource(req, { maxBytes: BACKUP_IMPORT_MAX_BYTES });
+            res.json({
+                ok: true,
+                assetsRestored: result.assetsRestored,
+                coldStorageFailed: result.coldStorageFailed,
+            });
+        }
     } catch (error) {
-        next(error);
+        if (wantsNdjson && res.headersSent) {
+            try {
+                res.write(JSON.stringify({ type: 'error', message: error?.message || 'backup import failed' }) + '\n');
+                res.end();
+            } catch (_) {}
+        } else {
+            next(error);
+        }
     } finally {
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
         importInProgress = false;
         if (req.socket.server && prevRequestTimeout !== undefined) {
             req.socket.server.requestTimeout = prevRequestTimeout;

--- a/src/ts/storage/nodeStorage.ts
+++ b/src/ts/storage/nodeStorage.ts
@@ -452,24 +452,63 @@ export class NodeStorage{
             xhr.setRequestHeader('content-type', 'application/x-risu-backup')
             xhr.setRequestHeader('risu-auth', authHeader)
             xhr.setRequestHeader('x-session-id', NodeStorage.sessionId)
+            // Opt into NDJSON streaming so the server keeps the response socket
+            // alive during long post-upload work — prevents reverse-proxy 502s.
+            xhr.setRequestHeader('accept', 'application/x-ndjson')
 
+            let uploadComplete = false
             xhr.upload.onprogress = (event) => {
                 if (event.lengthComputable) {
                     onProgress?.(event.loaded, event.total)
                 }
             }
+            xhr.upload.onload = () => { uploadComplete = true }
 
+            let parsedIndex = 0
+            let leftover = ''
+            let result: {ok: boolean, assetsRestored: number, coldStorageFailed?: number} | null = null
+            let serverErrorMsg: string | null = null
+
+            const drainNdjson = () => {
+                const text = xhr.responseText
+                if (text.length <= parsedIndex) return
+                leftover += text.slice(parsedIndex)
+                parsedIndex = text.length
+                const lines = leftover.split('\n')
+                leftover = lines.pop() ?? ''
+                for (const line of lines) {
+                    if (!line) continue
+                    let msg: any
+                    try { msg = JSON.parse(line) } catch { continue }
+                    if (msg.type === 'progress' && uploadComplete) {
+                        // After upload finishes, surface server-side processing
+                        // progress through the same callback for UI continuity.
+                        onProgress?.(msg.bytes, msg.totalBytes)
+                    } else if (msg.type === 'done') {
+                        result = msg
+                    } else if (msg.type === 'error') {
+                        serverErrorMsg = typeof msg.message === 'string' ? msg.message : 'backup import failed'
+                    }
+                    // Ignore 'heartbeat' and unknown event types.
+                }
+            }
+
+            xhr.onprogress = drainNdjson
             xhr.onerror = () => reject(new Error('backup import request failed'))
             xhr.onload = () => {
                 if (xhr.status < 200 || xhr.status >= 300) {
-                    reject(new Error(`backup import error: ${xhr.status}`))
+                    let msg = `backup import error: ${xhr.status}`
+                    try {
+                        const body = JSON.parse(xhr.responseText)
+                        if (body?.error) msg = String(body.error)
+                    } catch {}
+                    reject(new Error(msg))
                     return
                 }
-                try {
-                    resolve(JSON.parse(xhr.responseText))
-                } catch (error) {
-                    reject(error)
-                }
+                drainNdjson()
+                if (serverErrorMsg) reject(new Error(serverErrorMsg))
+                else if (result) resolve(result)
+                else reject(new Error('backup import: no result received'))
             }
 
             xhr.send(file)

--- a/test/compat/backup-roundtrip.test.ts
+++ b/test/compat/backup-roundtrip.test.ts
@@ -213,6 +213,316 @@ describe('content-type compatibility', () => {
   })
 })
 
+// ─── NDJSON streaming response ──────────────────────────────────────────────
+//
+// The NDJSON import path was added to keep the response socket alive during
+// long post-upload work (WAL checkpoint, cold-storage migration, etc.) so a
+// reverse proxy in front of the Node server doesn't time out and bounce a 502
+// back to the client. Backup import is one of the most destructive operations
+// in the app — a silent failure or partial import would wipe user data — so
+// these tests guard the contract end-to-end:
+//
+//   T1  database content survives the NDJSON path identically
+//   T2  asset bytes survive the NDJSON path identically
+//   T3  cold-storage migration (runs in the silent post-upload phase) succeeds
+//   T4  a malformed backup ends in an `error` event with prior data intact
+//       (the worst case here is `done.ok=true` arriving on a botched import)
+//   T5  `progress` events fire with monotonically increasing bytes
+//   T6  heartbeats actually fire during processing (proves the keepalive
+//       mechanism — without it the fix degrades to a silent 502 again)
+
+type NdjsonEvent =
+  | { type: 'progress'; bytes: number; totalBytes: number }
+  | { type: 'heartbeat' }
+  | { type: 'done'; ok: boolean; assetsRestored?: number; coldStorageFailed?: number }
+  | { type: 'error'; message: string }
+
+interface NdjsonImportResult {
+  response: Response
+  events: NdjsonEvent[]
+  done?: Extract<NdjsonEvent, { type: 'done' }>
+  errors: Array<Extract<NdjsonEvent, { type: 'error' }>>
+  progresses: Array<Extract<NdjsonEvent, { type: 'progress' }>>
+  heartbeats: Array<Extract<NdjsonEvent, { type: 'heartbeat' }>>
+}
+
+async function importViaNdjson(
+  client: { fetch: (path: string, init?: RequestInit) => Promise<Response> },
+  seed: Buffer,
+): Promise<NdjsonImportResult> {
+  const prepRes = await client.fetch('/api/backup/import/prepare', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ size: seed.byteLength }),
+  })
+  if (!prepRes.ok) throw new Error(`prepare failed: ${prepRes.status} ${await prepRes.text()}`)
+
+  const response = await client.fetch('/api/backup/import', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-risu-backup',
+      'accept': 'application/x-ndjson',
+    },
+    body: new Uint8Array(seed),
+  })
+  const text = await response.text()
+  const events: NdjsonEvent[] = text
+    .split('\n')
+    .filter(line => line.length > 0)
+    .map(line => JSON.parse(line) as NdjsonEvent)
+
+  return {
+    response,
+    events,
+    done: events.find((e): e is Extract<NdjsonEvent, { type: 'done' }> => e.type === 'done'),
+    errors: events.filter((e): e is Extract<NdjsonEvent, { type: 'error' }> => e.type === 'error'),
+    progresses: events.filter((e): e is Extract<NdjsonEvent, { type: 'progress' }> => e.type === 'progress'),
+    heartbeats: events.filter((e): e is Extract<NdjsonEvent, { type: 'heartbeat' }> => e.type === 'heartbeat'),
+  }
+}
+
+describe('ndjson streaming import', () => {
+  // T1 — DB content must come through unchanged via the NDJSON path. A
+  // regression that bypassed importBackupFromSource (or short-circuited it)
+  // would be the worst-case silent corruption; we compare normalized output
+  // to a baseline produced by the existing non-NDJSON path on a peer server.
+  test('T1: round-trip database matches non-NDJSON path byte-for-byte (normalized)', async () => {
+    const seed = createSeedBackup({ characterCount: 3, chatsPerCharacter: 2, messagesPerChat: 4 })
+
+    const srvBaseline = await spawnServer()
+    servers.push(srvBaseline)
+    const clientBaseline = await createClient(srvBaseline.port, srvBaseline.password)
+    await clientBaseline.importBackup(seed)
+    const baselineExport = await clientBaseline.exportBackup()
+
+    const srvNdjson = await spawnServer()
+    servers.push(srvNdjson)
+    const clientNdjson = await createClient(srvNdjson.port, srvNdjson.password)
+    const ndjson = await importViaNdjson(clientNdjson, seed)
+    expect(ndjson.response.ok).toBe(true)
+    expect(ndjson.done?.ok).toBe(true)
+    const ndjsonExport = await clientNdjson.exportBackup()
+
+    const baseline = normalizeBackup(baselineExport)
+    const fromNdjson = normalizeBackup(ndjsonExport)
+    expect(fromNdjson.normalized.characterCount).toBe(baseline.normalized.characterCount)
+    expect(fromNdjson.normalized.characters).toEqual(baseline.normalized.characters)
+    expect(fromNdjson.normalized.personaCount).toBe(baseline.normalized.personaCount)
+  })
+
+  // T2 — asset bytes are written via a different code path than the DB
+  // (kv writes vs sqlite restore). Fingerprint compare guards against any
+  // off-by-one truncation or accidental skipping when streaming the body.
+  test('T2: assets survive the NDJSON path with identical fingerprints', async () => {
+    const seed = createSeedBackup({ characterCount: 2, includeAssets: true })
+    const seedFingerprints = fingerprintAssets(seed)
+    expect(seedFingerprints.length).toBe(2)
+
+    const srv = await spawnServer()
+    servers.push(srv)
+    const client = await createClient(srv.port, srv.password)
+
+    const ndjson = await importViaNdjson(client, seed)
+    expect(ndjson.done?.ok).toBe(true)
+    expect(ndjson.errors).toEqual([])
+
+    const exported = await client.exportBackup()
+    expect(fingerprintAssets(exported)).toEqual(seedFingerprints)
+  })
+
+  // T3 — cold-storage migration runs *after* the body finishes streaming,
+  // which is exactly the silent phase the heartbeat is meant to cover. We
+  // assert both that the migration succeeded (coldStorageFailed=0) and that
+  // the restored character is present in the re-export.
+  test('T3: cold-storage character is restored when imported via NDJSON', async () => {
+    const fullCharData = {
+      character: {
+        name: 'NdjsonColdChar',
+        chaId: 'cold-char-ndjson-key',
+        image: '', type: 'character',
+        desc: 'Imported via NDJSON',
+        firstMessage: 'Hello from NDJSON path!',
+        chats: [{
+          message: [{ role: 'char', data: 'Hello from NDJSON path!' }],
+          note: '', name: 'Chat 1', localLore: [],
+        }],
+        chatPage: 0, firstMsgIndex: -1,
+        notes: '', emotionImages: [], bias: [], globalLore: [],
+        viewScreen: 'none', sdData: [], utilityBot: false,
+        customscript: [], triggerscript: [],
+        exampleMessage: '', creatorNotes: '', systemPrompt: '',
+        postHistoryInstructions: '', alternateGreetings: [],
+        tags: [], creator: '', characterVersion: '',
+        personality: '', scenario: '', replaceGlobalNote: '',
+        additionalText: '', chatFolders: [],
+      },
+    }
+
+    const seed = createSeedBackup({
+      characterCount: 1,
+      coldStorageCharacters: [
+        { name: 'NdjsonColdChar', coldKey: 'ndjson-key', fullData: fullCharData },
+      ],
+    })
+
+    const srv = await spawnServer()
+    servers.push(srv)
+    const client = await createClient(srv.port, srv.password)
+
+    const ndjson = await importViaNdjson(client, seed)
+    expect(ndjson.done?.ok).toBe(true)
+    expect(ndjson.done?.coldStorageFailed ?? 0).toBe(0)
+
+    const { normalized } = normalizeBackup(await client.exportBackup())
+    const restored = normalized.characters.find(c => c.chaId === 'cold-char-ndjson-key')
+    expect(restored).toBeDefined()
+    expect(restored!.name).toBe('NdjsonColdChar')
+    expect(restored!.firstMessages[0]).toBe('Hello from NDJSON path!')
+  })
+
+  // T4 — silent failure is the worst-case bug. If a malformed backup got
+  // anywhere near a `done.ok=true` event the UI would tell the user that
+  // their import succeeded while their existing data was actually wiped.
+  // The NDJSON path must surface an `error` event AND leave prior data intact.
+  test('T4: malformed backup emits error event, no done, prior data intact', async () => {
+    const srv = await spawnServer()
+    servers.push(srv)
+    const client = await createClient(srv.port, srv.password)
+
+    const goodSeed = createSeedBackup({ characterCount: 1 })
+    await client.importBackup(goodSeed)
+    const beforeExport = await client.exportBackup()
+    const before = normalizeBackup(beforeExport)
+
+    const badBackup = encodeBackup([
+      { name: 'some-random-asset.png', data: Buffer.from('not-a-real-png') },
+    ])
+
+    const ndjson = await importViaNdjson(client, badBackup)
+    expect(ndjson.errors.length).toBeGreaterThanOrEqual(1)
+    expect(ndjson.done).toBeUndefined()
+
+    const afterExport = await client.exportBackup()
+    const after = normalizeBackup(afterExport)
+    expect(after.normalized.characterCount).toBe(before.normalized.characterCount)
+    expect(after.normalized.characters).toEqual(before.normalized.characters)
+  })
+
+  // T5 — progress events are the contract the UI relies on to drive its
+  // upload progress bar. If a refactor accidentally drops the onProgress
+  // callback or rewires it to fire only once, the UI silently regresses.
+  test('T5: emits at least one progress event with monotonically increasing bytes', async () => {
+    const seed = createSeedBackup({ characterCount: 5, chatsPerCharacter: 3, messagesPerChat: 6, includeAssets: true })
+
+    const srv = await spawnServer()
+    servers.push(srv)
+    const client = await createClient(srv.port, srv.password)
+
+    const ndjson = await importViaNdjson(client, seed)
+    expect(ndjson.done?.ok).toBe(true)
+    expect(ndjson.progresses.length).toBeGreaterThanOrEqual(1)
+
+    let last = -1
+    for (const p of ndjson.progresses) {
+      expect(p.bytes).toBeGreaterThanOrEqual(last)
+      expect(p.totalBytes).toBe(seed.byteLength)
+      last = p.bytes
+    }
+    expect(last).toBeLessThanOrEqual(seed.byteLength)
+  })
+
+  // T6 — this is *the* reason the patch exists. If a future change drops
+  // the setInterval call, every data test above keeps passing (small fixtures
+  // finish before one heartbeat tick) but the production 502 would come back.
+  //
+  // Two things have to line up to observe a heartbeat at all:
+  //   1. The heartbeat interval has to be short. We pin it to the floor
+  //      (100 ms) via env override.
+  //   2. The server has to spend more than one interval on the request, AND
+  //      yield to the event loop while doing so (setInterval can't fire while
+  //      JS is in a sync block). With a single-chunk Uint8Array body the
+  //      whole import collapses into one for-await tick. So we stream the
+  //      body in pieces with deliberate 60 ms gaps to force several yields.
+  test('T6: heartbeats fire during processing when interval is tight', async () => {
+    const srv = await spawnServer({ env: { BACKUP_NDJSON_HEARTBEAT_MS: '100' } })
+    servers.push(srv)
+    const client = await createClient(srv.port, srv.password)
+
+    const seed = createSeedBackup({ characterCount: 2, includeAssets: true })
+
+    const prepRes = await client.fetch('/api/backup/import/prepare', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ size: seed.byteLength }),
+    })
+    expect(prepRes.ok).toBe(true)
+
+    const chunkSize = Math.max(1, Math.ceil(seed.byteLength / 5))
+    let offset = 0
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (offset >= seed.byteLength) { controller.close(); return }
+        const end = Math.min(offset + chunkSize, seed.byteLength)
+        const chunk = new Uint8Array(seed.subarray(offset, end))
+        offset = end
+        if (offset < seed.byteLength) await new Promise(r => setTimeout(r, 60))
+        controller.enqueue(chunk)
+      },
+    })
+
+    const response = await client.fetch('/api/backup/import', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-risu-backup',
+        'accept': 'application/x-ndjson',
+        'content-length': String(seed.byteLength),
+      },
+      body: body as unknown as BodyInit,
+      // Node's fetch requires this flag for streaming request bodies.
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' })
+
+    const text = await response.text()
+    const events: NdjsonEvent[] = text
+      .split('\n')
+      .filter(line => line.length > 0)
+      .map(line => JSON.parse(line) as NdjsonEvent)
+    const done = events.find((e): e is Extract<NdjsonEvent, { type: 'done' }> => e.type === 'done')
+    const heartbeats = events.filter(e => e.type === 'heartbeat')
+
+    expect(done?.ok).toBe(true)
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1)
+  })
+
+  // Backwards-compat sanity: a client that doesn't advertise NDJSON must
+  // still get the legacy JSON response. The non-NDJSON branch is what every
+  // integration helper in this file already exercises, but an explicit
+  // negative test makes the contract surface visible.
+  test('legacy clients without Accept header receive JSON, not NDJSON', async () => {
+    const srv = await spawnServer()
+    servers.push(srv)
+    const client = await createClient(srv.port, srv.password)
+
+    const seed = createSeedBackup({ characterCount: 1 })
+
+    const prepRes = await client.fetch('/api/backup/import/prepare', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ size: seed.byteLength }),
+    })
+    expect(prepRes.ok).toBe(true)
+
+    const impRes = await client.fetch('/api/backup/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-risu-backup' },
+      body: new Uint8Array(seed),
+    })
+    expect(impRes.headers.get('content-type')).toContain('application/json')
+    const body = await impRes.json() as { ok: boolean }
+    expect(body.ok).toBe(true)
+  })
+})
+
 // ─── Malformed import safety ────────────────────────────────────────────────
 
 describe('malformed import safety', () => {

--- a/test/compat/helpers/spawnServer.ts
+++ b/test/compat/helpers/spawnServer.ts
@@ -41,7 +41,12 @@ async function getFreePort(): Promise<number> {
   })
 }
 
-export async function spawnServer(): Promise<ServerHandle> {
+export interface SpawnServerOptions {
+  /** Extra env vars to pass to the spawned server process. */
+  env?: Record<string, string>
+}
+
+export async function spawnServer(opts: SpawnServerOptions = {}): Promise<ServerHandle> {
   const tempDir = await mkdtemp(path.join(tmpdir(), 'risu-compat-'))
   await mkdir(path.join(tempDir, 'save'), { recursive: true })
   await mkdir(path.join(tempDir, 'backups'), { recursive: true })
@@ -54,7 +59,7 @@ export async function spawnServer(): Promise<ServerHandle> {
     [SERVER_SCRIPT],
     {
       cwd: tempDir,
-      env: { ...process.env, PORT: String(port), NODE_ENV: 'test' },
+      env: { ...process.env, PORT: String(port), NODE_ENV: 'test', ...opts.env },
       stdio: ['ignore', 'pipe', 'pipe'],
     },
   )


### PR DESCRIPTION
Backup imports could fail with `backup import error: 502` when a reverse
proxy (nginx, Cloudflare Tunnel, etc.) sat between the browser and the
Node server. After the upload finished, post-processing (WAL checkpoint,
inlay dir swap, cold-storage migration) ran for tens of seconds with no
bytes flowing back, so the proxy's response timeout fired and bounced a
502 to the client.

The /api/backup/server/restore endpoint already solves this by streaming
NDJSON progress events. This change opts /api/backup/import into the same
pattern when the client sends `Accept: application/x-ndjson`:

- Server flushes headers up front, emits progress events while consuming
  the upload, and a 5s heartbeat covers the silent post-stream phase.
  Existing JSON-response behavior is preserved when the header is absent
  so the integration test helpers stay untouched.
- Browser client opts in, parses NDJSON incrementally from
  xhr.responseText, and surfaces server-side processing progress through
  the same onProgress callback used for upload bytes.

Adds an integration test that exercises the streaming response path.