### PR TITLE
fix(chat): disable translation controls while translating

### DIFF
--- a/src/lib/ChatScreens/Chat.svelte
+++ b/src/lib/ChatScreens/Chat.svelte
@@ -337,8 +337,10 @@
         {/if}
         {#if DBState.db.translatorType === 'llm' && translated}
             <button class="text-sm p-1 text-textcolor2 border-darkborderc float-end mr-2 my-1
-                            hover:ring-darkbutton hover:ring-3 rounded-md hover:text-textcolor transition-all flex justify-center items-center"
+                            hover:ring-darkbutton hover:ring-3 rounded-md hover:text-textcolor transition-all flex justify-center items-center disabled:opacity-60 disabled:cursor-not-allowed"
+                    disabled={translating}
                     onclick={() => {
+                        if(translating) return
                         retranslate = true
                     }}
             >
@@ -347,8 +349,10 @@
                     {language.retranslate}
                 </span>
             </button>
-            <button class={"text-sm p-1 border-darkborderc float-end mr-2 my-1 hover:ring-darkbutton hover:ring-3 rounded-md hover:text-textcolor transition-all flex justify-center items-center " + (editTranslationMode ? 'text-blue-400' : 'text-textcolor2')}
+            <button class={"text-sm p-1 border-darkborderc float-end mr-2 my-1 hover:ring-darkbutton hover:ring-3 rounded-md hover:text-textcolor transition-all flex justify-center items-center disabled:opacity-60 disabled:cursor-not-allowed " + (editTranslationMode ? 'text-blue-400' : 'text-textcolor2')}
+                    disabled={translating}
                     onclick={() => {
+                        if(translating) return
                         if(editTranslationMode){
                             saveTranslationEdit()
                         }
@@ -757,7 +761,8 @@
 
 {#snippet translationButton(showNames = false)}
     {#if DBState.db.translator !== '' && !blankMessage}
-        <button class={"flex items-center cursor-pointer hover:text-primary transition-colors button-icon-translate " + (translated ? 'text-blue-400':'')} class:translating={translating} onclick={async () => {
+        <button class={"flex items-center cursor-pointer hover:text-primary transition-colors button-icon-translate disabled:opacity-60 disabled:cursor-not-allowed " + (translated ? 'text-blue-400':'')} class:translating={translating} disabled={translating} onclick={async () => {
+            if(translating) return
             translated = !translated
         }}>
             <LanguagesIcon />
@@ -767,7 +772,8 @@
         </button>
     {/if}
     {#if idx > -1}
-        <button class={"flex items-center hover:text-primary transition-colors button-icon-edit "+(editMode?'text-blue-400':'')} onclick={() => {
+        <button class={"flex items-center hover:text-primary transition-colors button-icon-edit disabled:opacity-60 disabled:cursor-not-allowed "+(editMode?'text-blue-400':'')} disabled={translating} onclick={() => {
+            if(translating) return
             if(!editMode){
                 editMode = true
             }
@@ -789,18 +795,19 @@
     {#if (rerollIcon || altGreeting) && role !== 'user'}
         {#if altGreeting}
             <!-- First message: ← counter → -->
-            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-unreroll" onclick={unReroll}>
+            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-unreroll disabled:opacity-60 disabled:cursor-not-allowed" disabled={translating} onclick={() => { if(translating) return; unReroll() }}>
                 <ArrowLeft size={22}/>
             </button>
             {#if !DBState.db.hideMessagePageCount}
                 <span class="flex items-center text-xs text-textcolor2 shrink overflow-hidden whitespace-nowrap min-w-0">{currentPage}/{totalPages}</span>
             {/if}
-            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-reroll" onclick={onReroll}>
+            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-reroll disabled:opacity-60 disabled:cursor-not-allowed" disabled={translating} onclick={() => { if(translating) return; onReroll() }}>
                 <ArrowRight size={22}/>
             </button>
         {:else}
             <!-- Normal messages: ← counter → ↻ -->
-            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-unreroll" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} onclick={async () => {
+            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-unreroll disabled:opacity-60 disabled:cursor-not-allowed" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} disabled={translating} onclick={async () => {
+                if(translating) return
                 if (totalPages <= 1) {
                     if (!DBState.db.confirmReroll || await alertConfirm(language.noSwipesRerollConfirm)) onReroll()
                 } else {
@@ -812,7 +819,8 @@
             {#if !DBState.db.hideMessagePageCount}
                 <span class="flex items-center text-xs text-textcolor2 shrink overflow-hidden whitespace-nowrap min-w-0" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'}>{currentPage}/{totalPages}</span>
             {/if}
-            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} onclick={async () => {
+            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-reroll disabled:opacity-60 disabled:cursor-not-allowed" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} disabled={translating} onclick={async () => {
+                if(translating) return
                 if (totalPages <= 1) {
                     if (!DBState.db.confirmReroll || await alertConfirm(language.noSwipesRerollConfirm)) onReroll()
                 } else {
@@ -821,7 +829,8 @@
             }}>
                 <ArrowRight size={22}/>
             </button>
-            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-reroll" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} onclick={async () => {
+            <button class="flex items-center shrink-0 hover:text-primary transition-colors button-icon-reroll disabled:opacity-60 disabled:cursor-not-allowed" class:dyna-icon={rerollIcon === 'dynamic' || rerollIcon === 'force'} class:force-show={rerollIcon === 'force'} disabled={translating} onclick={async () => {
+                if(translating) return
                 if (!DBState.db.confirmReroll || await alertConfirm(language.rerollConfirm)) onReroll()
             }}>
                 <RefreshCcwIcon size={20}/>

--- a/src/lib/ChatScreens/ChatBody.svelte
+++ b/src/lib/ChatScreens/ChatBody.svelte
@@ -3,7 +3,7 @@
     import { DBState } from 'src/ts/stores.svelte'
     import { sleep } from "src/ts/util"
     import { alertError } from "../../ts/alert"
-    import { tick } from 'svelte'
+    import { tick, untrack } from 'svelte'
     import { addMetadataToElement, getDistance, ParseMarkdown, postTranslationParse, resolveInlayPlaceholders, trimMarkdown, type CbsConditions, type simpleCharacterArgument } from "../../ts/parser/parser.svelte"
     import { getLLMCache, translateHTML } from "../../ts/translator/translator"
     import { getModuleAssets } from "src/ts/process/modules";
@@ -41,6 +41,7 @@
     let lastParsed = ''
     let lastCharArg:string|simpleCharacterArgument = null
     let lastChatId = -10
+    let inflightTranslation: Promise<string> | null = null
 
     function getCbsCondition(){
         try{
@@ -102,39 +103,75 @@
                 }
             }
             if(retranslate || translated){
+                if(untrack(() => translating) && inflightTranslation){
+                    return inflightTranslation
+                }
+
                 if (DBState.db.showTranslationLoading) {
                     lastParsed = `<div style="display:flex;justify-content:center;align-items:center;height:48px;"><div style="animation: spin 1s linear infinite; border-radius: 50%; height: 32px; width: 32px; border: 2px solid #3b82f6; border-top: 2px solid transparent;"></div></div><style>@keyframes spin { to { transform: rotate(360deg); } }</style>`
                 }
 
                 let transResult
-                
+
                 if(DBState.db.translatorType === 'llm' && DBState.db.translateBeforeHTMLFormatting){
-                    await sleep(100)
-                    translating = true
-                    data = await translateHTML(data, false, charArg, chatID, retranslate)
-                    translating = false
-                    const marked = await ParseMarkdown(data, charArg, mode, chatID, getCbsCondition())
-                    lastParsedQueue = marked
-                    lastCharArg = charArg
-                    transResult = marked
+                    inflightTranslation = (async () => {
+                        await sleep(100)
+                        translating = true
+                        let translatedData = ''
+                        try {
+                            translatedData = await translateHTML(data, false, charArg, chatID, retranslate)
+                        }
+                        finally {
+                            translating = false
+                        }
+                        const marked = await ParseMarkdown(translatedData, charArg, mode, chatID, getCbsCondition())
+                        lastParsedQueue = marked
+                        lastCharArg = charArg
+                        return marked
+                    })()
                 }
                 else if(!DBState.db.legacyTranslation){
-                    const marked = await ParseMarkdown(data, charArg, 'pretranslate', chatID, getCbsCondition())
-                    translating = true
-                    const translated = await postTranslationParse(await translateHTML(marked, false, charArg, chatID, retranslate))
-                    translating = false
-                    lastParsedQueue = translated
-                    lastCharArg = charArg
-                    transResult = translated
+                    inflightTranslation = (async () => {
+                        
+                        translating = true
+                        let translatedHtml = ''
+                        let translated = ''
+                        try {
+                            const marked = await ParseMarkdown(data, charArg, 'pretranslate', chatID, getCbsCondition())
+                            translatedHtml = await translateHTML(marked, false, charArg, chatID, retranslate)
+                            translated = await postTranslationParse(translatedHtml)
+                        }
+                        finally {
+                            translating = false
+                        }
+                        
+                        lastParsedQueue = translated
+                        lastCharArg = charArg
+                        return translated
+                    })()
                 }
                 else{
-                    const marked = await ParseMarkdown(data, charArg, mode, chatID, getCbsCondition())
-                    translating = true
-                    const translated = await translateHTML(marked, false, charArg, chatID, retranslate)
-                    translating = false
-                    lastParsedQueue = translated
-                    lastCharArg = charArg
-                    transResult = translated
+                    inflightTranslation = (async () => {
+                        translating = true
+                        let translated = ''
+                        try {
+                            const marked = await ParseMarkdown(data, charArg, mode, chatID, getCbsCondition())
+                            translated = await translateHTML(marked, false, charArg, chatID, retranslate)
+                        }
+                        finally {
+                            translating = false
+                        }
+                        lastParsedQueue = translated
+                        lastCharArg = charArg
+                        return translated
+                    })()
+                }
+
+                try {
+                    transResult = await inflightTranslation
+                }
+                finally {
+                    inflightTranslation = null
                 }
 
                 setTimeout(() => {
@@ -160,7 +197,9 @@
         }
         finally{
             //since trimMarkdown is fast, we don't need to cache it
-            lastParsed = lastParsedQueue
+            if(lastParsedQueue !== ''){
+                lastParsed = lastParsedQueue
+            }
         }
     }
 

--- a/src/lib/ChatScreens/ChatBody.svelte
+++ b/src/lib/ChatScreens/ChatBody.svelte
@@ -3,7 +3,7 @@
     import { DBState } from 'src/ts/stores.svelte'
     import { sleep } from "src/ts/util"
     import { alertError } from "../../ts/alert"
-    import { tick, untrack } from 'svelte'
+    import { tick } from 'svelte'
     import { addMetadataToElement, getDistance, ParseMarkdown, postTranslationParse, resolveInlayPlaceholders, trimMarkdown, type CbsConditions, type simpleCharacterArgument } from "../../ts/parser/parser.svelte"
     import { getLLMCache, translateHTML } from "../../ts/translator/translator"
     import { getModuleAssets } from "src/ts/process/modules";
@@ -103,7 +103,7 @@
                 }
             }
             if(retranslate || translated){
-                if(untrack(() => translating) && inflightTranslation){
+                if(inflightTranslation){
                     return inflightTranslation
                 }
 
@@ -115,55 +115,49 @@
 
                 if(DBState.db.translatorType === 'llm' && DBState.db.translateBeforeHTMLFormatting){
                     inflightTranslation = (async () => {
-                        await sleep(100)
                         translating = true
-                        let translatedData = ''
                         try {
-                            translatedData = await translateHTML(data, false, charArg, chatID, retranslate)
+                            await sleep(100)
+                            const translatedData = await translateHTML(data, false, charArg, chatID, retranslate)
+                            const marked = await ParseMarkdown(translatedData, charArg, mode, chatID, getCbsCondition())
+                            lastParsedQueue = marked
+                            lastCharArg = charArg
+                            return marked
                         }
                         finally {
                             translating = false
                         }
-                        const marked = await ParseMarkdown(translatedData, charArg, mode, chatID, getCbsCondition())
-                        lastParsedQueue = marked
-                        lastCharArg = charArg
-                        return marked
                     })()
                 }
                 else if(!DBState.db.legacyTranslation){
                     inflightTranslation = (async () => {
-                        
                         translating = true
-                        let translatedHtml = ''
-                        let translated = ''
                         try {
                             const marked = await ParseMarkdown(data, charArg, 'pretranslate', chatID, getCbsCondition())
-                            translatedHtml = await translateHTML(marked, false, charArg, chatID, retranslate)
-                            translated = await postTranslationParse(translatedHtml)
+                            const translatedHtml = await translateHTML(marked, false, charArg, chatID, retranslate)
+                            const translated = await postTranslationParse(translatedHtml)
+                            lastParsedQueue = translated
+                            lastCharArg = charArg
+                            return translated
                         }
                         finally {
                             translating = false
                         }
-                        
-                        lastParsedQueue = translated
-                        lastCharArg = charArg
-                        return translated
                     })()
                 }
                 else{
                     inflightTranslation = (async () => {
                         translating = true
-                        let translated = ''
                         try {
                             const marked = await ParseMarkdown(data, charArg, mode, chatID, getCbsCondition())
-                            translated = await translateHTML(marked, false, charArg, chatID, retranslate)
+                            const translated = await translateHTML(marked, false, charArg, chatID, retranslate)
+                            lastParsedQueue = translated
+                            lastCharArg = charArg
+                            return translated
                         }
                         finally {
                             translating = false
                         }
-                        lastParsedQueue = translated
-                        lastCharArg = charArg
-                        return translated
                     })()
                 }
 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Prevents chat message actions from running while a translation is in progress.

## Related Issues

None

## Changes

- Disables translate, retranslate, edit, and reroll/swipe buttons during translation.
- Adds disabled styling and click guards for translation-sensitive chat controls.
- Tracks in-flight translation work to avoid duplicate translation runs.
- Ensures `translating` is reset with `finally` when translation processing fails.
- Avoids replacing the rendered message with an empty parse result.

## Impact

Users can no longer edit, reroll, swipe, or retrigger translation while the current translation is still processing, reducing race conditions and inconsistent message state.

## Demo

https://github.com/user-attachments/assets/5543bf95-12c9-40ea-80d3-104b4d21a8b9