### PR TITLE
Add safe lazy chat sync and validated startup caching

### DIFF
--- a/server/node/chatDelta.cjs
+++ b/server/node/chatDelta.cjs
@@ -1,0 +1,183 @@
+'use strict';
+
+const crypto = require('crypto');
+const { applyPatch } = require('fast-json-patch');
+const { encodeRisuSaveLegacy, normalizeJSON } = require('./utils.cjs');
+
+const MAX_CHAT_PATCH_OPERATIONS = 10_000;
+const BLOCKED_POINTER_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+const ALLOWED_OPERATIONS = new Set(['add', 'replace', 'remove']);
+const CHAT_STUB_FIELDS = new Set(['id', 'name', '_stub', 'lastDate', 'folderId', 'modules']);
+
+function chatRevision(chat) {
+    return crypto
+        .createHash('sha256')
+        .update(Buffer.from(encodeRisuSaveLegacy(chat)))
+        .digest('hex');
+}
+
+function evaluateChatRevisionPrecondition(chat, baseRevision) {
+    const currentRevision = chat ? chatRevision(chat) : null;
+    return {
+        currentRevision,
+        matches: !baseRevision || currentRevision === baseRevision,
+    };
+}
+
+function evaluateFullChatWritePrecondition(chat, { baseRevision = '', createOnly = false } = {}) {
+    const currentRevision = chat ? chatRevision(chat) : null;
+    if (createOnly) {
+        return {
+            currentRevision,
+            matches: !chat,
+            status: chat ? 412 : null,
+            error: chat ? 'Chat already exists' : null,
+        };
+    }
+    if (chat && !baseRevision) {
+        return {
+            currentRevision,
+            matches: false,
+            status: 428,
+            error: 'A base revision is required to replace an existing chat',
+        };
+    }
+    const matches = !baseRevision ? !chat : currentRevision === baseRevision;
+    return {
+        currentRevision,
+        matches,
+        status: matches ? null : 409,
+        error: matches ? null : 'Chat revision mismatch',
+    };
+}
+
+function validatePointer(path) {
+    if (typeof path !== 'string' || !path.startsWith('/')) {
+        throw new Error('Chat patch paths must be non-root JSON pointers');
+    }
+    if (/~(?:[^01]|$)/.test(path)) {
+        throw new Error('Chat patch contains an invalid JSON pointer escape');
+    }
+    const segments = path.slice(1).split('/').map((segment) =>
+        segment.replace(/~1/g, '/').replace(/~0/g, '~')
+    );
+    if (segments.some((segment) => BLOCKED_POINTER_SEGMENTS.has(segment))) {
+        throw new Error('Chat patch contains a blocked object path');
+    }
+}
+
+function validateChatPatch(patch) {
+    if (!Array.isArray(patch)) throw new Error('Chat patch must be an array');
+    if (patch.length > MAX_CHAT_PATCH_OPERATIONS) {
+        throw new Error(`Chat patch exceeds ${MAX_CHAT_PATCH_OPERATIONS} operations`);
+    }
+    for (const operation of patch) {
+        if (!operation || typeof operation !== 'object' || !ALLOWED_OPERATIONS.has(operation.op)) {
+            throw new Error('Chat patch contains an unsupported operation');
+        }
+        validatePointer(operation.path);
+    }
+}
+
+function applyChatDelta(chat, patch, expectedChatId) {
+    validateChatPatch(patch);
+    const snapshot = normalizeJSON(JSON.parse(JSON.stringify(chat)));
+    const result = applyPatch(snapshot, patch, true, true, true).newDocument;
+
+    if (!result || typeof result !== 'object' || !Array.isArray(result.message)) {
+        throw new Error('Chat patch produced an invalid chat');
+    }
+    if (expectedChatId && result.id !== expectedChatId) {
+        throw new Error('Chat patch cannot change the chat ID');
+    }
+    return result;
+}
+
+/**
+ * A brand-new client may persist the encoder's empty object before runtime
+ * defaults create `characters`. Supply only that missing top-level default;
+ * explicitly malformed values (null, object, string, etc.) remain untouched so
+ * validateStrippedDatabase rejects them instead of silently repairing data.
+ */
+function canonicalizeStrippedDatabase(database) {
+    if (!database || typeof database !== 'object' || Array.isArray(database)) {
+        return database;
+    }
+    if (!Object.prototype.hasOwnProperty.call(database, 'characters')) {
+        return { ...database, characters: [] };
+    }
+    return database;
+}
+
+/**
+ * Validate the canonical stubs-only database before replacing dbCache.
+ *
+ * `hasFullChat` is intentionally supplied by the server so this helper stays
+ * pure and testable. Chat identity is scoped to a character because the
+ * runtime store is Map<chaId, Map<chatId, Chat>>.
+ */
+function validateStrippedDatabase(database, hasFullChat) {
+    if (!database || typeof database !== 'object' || !Array.isArray(database.characters)) {
+        throw new Error('Database characters must be an array');
+    }
+    if (typeof hasFullChat !== 'function') {
+        throw new Error('Full-chat lookup is required');
+    }
+
+    const characterIds = new Set();
+    for (let characterIndex = 0; characterIndex < database.characters.length; characterIndex++) {
+        const character = database.characters[characterIndex];
+        const chaId = character?.chaId;
+        if (typeof chaId !== 'string' || chaId.trim().length === 0) {
+            throw new Error(`Character ${characterIndex} has an empty chaId`);
+        }
+        if (characterIds.has(chaId)) {
+            throw new Error(`Duplicate chaId: ${chaId}`);
+        }
+        characterIds.add(chaId);
+
+        if (!Array.isArray(character.chats)) {
+            throw new Error(`Character ${chaId} chats must be an array`);
+        }
+        const chatIds = new Set();
+        for (let chatIndex = 0; chatIndex < character.chats.length; chatIndex++) {
+            const chat = character.chats[chatIndex];
+            const chatId = chat?.id;
+            if (!chat || typeof chat !== 'object' || Array.isArray(chat)) {
+                throw new Error(`Character ${chaId} chat ${chatIndex} is invalid`);
+            }
+            if (typeof chatId !== 'string' || chatId.trim().length === 0) {
+                throw new Error(`Character ${chaId} chat ${chatIndex} has an empty id`);
+            }
+            if (chatIds.has(chatId)) {
+                throw new Error(`Character ${chaId} has duplicate chat id: ${chatId}`);
+            }
+            chatIds.add(chatId);
+
+            if (chat._stub !== true || Array.isArray(chat.message)) {
+                throw new Error(`Character ${chaId} chat ${chatId} is not a canonical stub`);
+            }
+            const unexpectedFields = Object.keys(chat).filter((field) => !CHAT_STUB_FIELDS.has(field));
+            if (unexpectedFields.length > 0) {
+                throw new Error(
+                    `Character ${chaId} chat ${chatId} contains non-stub fields: ${unexpectedFields.join(', ')}`
+                );
+            }
+            if (!hasFullChat(chaId, chatId)) {
+                throw new Error(`Character ${chaId} chat ${chatId} has no full-chat payload`);
+            }
+        }
+    }
+    return true;
+}
+
+module.exports = {
+    MAX_CHAT_PATCH_OPERATIONS,
+    chatRevision,
+    evaluateChatRevisionPrecondition,
+    evaluateFullChatWritePrecondition,
+    validateChatPatch,
+    applyChatDelta,
+    canonicalizeStrippedDatabase,
+    validateStrippedDatabase,
+};

--- a/server/node/chatDelta.test.ts
+++ b/server/node/chatDelta.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import pkg from './chatDelta.cjs'
+
+const {
+    chatRevision,
+    evaluateChatRevisionPrecondition,
+    evaluateFullChatWritePrecondition,
+    applyChatDelta,
+    validateChatPatch,
+    canonicalizeStrippedDatabase,
+    validateStrippedDatabase,
+} = pkg as {
+    chatRevision: (chat: any) => string
+    evaluateChatRevisionPrecondition: (
+        chat: any,
+        baseRevision?: string,
+    ) => { currentRevision: string | null, matches: boolean }
+    evaluateFullChatWritePrecondition: (
+        chat: any,
+        options?: { baseRevision?: string, createOnly?: boolean },
+    ) => {
+        currentRevision: string | null
+        matches: boolean
+        status: number | null
+        error: string | null
+    }
+    applyChatDelta: (chat: any, patch: any[], expectedChatId: string) => any
+    validateChatPatch: (patch: any[]) => void
+    canonicalizeStrippedDatabase: (database: any) => any
+    validateStrippedDatabase: (database: any, hasFullChat: (chaId: string, chatId: string) => boolean) => boolean
+}
+
+function baseChat() {
+    return {
+        id: 'chat-1',
+        name: 'Session',
+        message: [
+            { chatId: 'u1', role: 'user', data: 'hello' },
+            { chatId: 'a1', role: 'char', data: 'hi', swipeId: 0, swipes: ['hi'] },
+        ],
+        localLore: [],
+        scriptstate: { archive: { turn: 1 } },
+    }
+}
+
+function strippedDatabase() {
+    return {
+        characters: [{
+            chaId: 'char-1',
+            chats: [{ id: 'chat-1', name: 'Session', _stub: true }],
+        }],
+    }
+}
+
+describe('incremental chat persistence', () => {
+    it('applies an appended user/assistant turn without replacing the full chat', () => {
+        const before = baseChat()
+        const after = structuredClone(before)
+        after.message.push(
+            { chatId: 'u2', role: 'user', data: 'next' },
+            { chatId: 'a2', role: 'char', data: 'answer', swipeId: 0, swipes: ['answer'] },
+        )
+        const patch = [
+            { op: 'add', path: '/message/2', value: after.message[2] },
+            { op: 'add', path: '/message/3', value: after.message[3] },
+        ]
+
+        expect(JSON.stringify(patch).length).toBeLessThan(JSON.stringify(after).length)
+        expect(applyChatDelta(before, patch, before.id)).toEqual(after)
+    })
+
+    it('preserves reroll/swipe replacement exactly', () => {
+        const before = baseChat()
+        const after = structuredClone(before)
+        after.message[1].swipes.push('rerolled')
+        after.message[1].swipeId = 1
+        after.message[1].data = 'rerolled'
+
+        const patch = [
+            { op: 'add', path: '/message/1/swipes/1', value: 'rerolled' },
+            { op: 'replace', path: '/message/1/swipeId', value: 1 },
+            { op: 'replace', path: '/message/1/data', value: 'rerolled' },
+        ]
+        expect(applyChatDelta(before, patch, before.id)).toEqual(after)
+    })
+
+    it('supports message deletion and plugin state changes', () => {
+        const before = baseChat()
+        const after = structuredClone(before)
+        after.message.splice(1, 1)
+        after.scriptstate.archive.turn = 0
+
+        const patch = [
+            { op: 'remove', path: '/message/1' },
+            { op: 'replace', path: '/scriptstate/archive/turn', value: 0 },
+        ]
+        expect(applyChatDelta(before, patch, before.id)).toEqual(after)
+    })
+
+    it('rejects unsupported operations, root paths, prototype paths, and chat ID replacement', () => {
+        const before = baseChat()
+        expect(() => validateChatPatch([{ op: 'move', from: '/name', path: '/note' }]))
+            .toThrow(/unsupported operation/i)
+        expect(() => validateChatPatch([{ op: 'replace', path: '', value: {} }]))
+            .toThrow(/non-root/i)
+        expect(() => validateChatPatch([{ op: 'replace', path: '/bad~2escape', value: {} }]))
+            .toThrow(/invalid JSON pointer escape/i)
+        expect(() => applyChatDelta(before, [{ op: 'add', path: '/__proto__/polluted', value: true }], before.id))
+            .toThrow(/blocked object path/i)
+        expect(() => applyChatDelta(before, [{ op: 'replace', path: '/id', value: 'other' }], before.id))
+            .toThrow(/chat ID/i)
+    })
+
+    it('rejects a delta that removes the message array', () => {
+        const before = baseChat()
+        expect(() => applyChatDelta(before, [{ op: 'remove', path: '/message' }], before.id))
+            .toThrow(/invalid chat/i)
+    })
+
+    it('evaluates full-save revision preconditions without treating an absent precondition as a conflict', () => {
+        const chat = baseChat()
+        const revision = chatRevision(chat)
+        expect(evaluateChatRevisionPrecondition(chat, undefined)).toEqual({
+            currentRevision: revision,
+            matches: true,
+        })
+        expect(evaluateChatRevisionPrecondition(chat, revision).matches).toBe(true)
+        expect(evaluateChatRevisionPrecondition(chat, 'stale').matches).toBe(false)
+        expect(evaluateChatRevisionPrecondition(null, revision)).toEqual({
+            currentRevision: null,
+            matches: false,
+        })
+    })
+
+    it('enforces create-only and CAS semantics for the full chat endpoint', () => {
+        const existing = baseChat()
+        const revision = chatRevision(existing)
+
+        expect(evaluateFullChatWritePrecondition(null, { createOnly: true })).toMatchObject({
+            matches: true,
+            status: null,
+        })
+        expect(evaluateFullChatWritePrecondition(existing, { createOnly: true })).toMatchObject({
+            currentRevision: revision,
+            matches: false,
+            status: 412,
+        })
+        expect(evaluateFullChatWritePrecondition(existing)).toMatchObject({
+            currentRevision: revision,
+            matches: false,
+            status: 428,
+        })
+        expect(evaluateFullChatWritePrecondition(existing, { baseRevision: revision })).toMatchObject({
+            matches: true,
+            status: null,
+        })
+        expect(evaluateFullChatWritePrecondition(null, { baseRevision: revision })).toMatchObject({
+            currentRevision: null,
+            matches: false,
+            status: 409,
+        })
+    })
+})
+
+describe('stripped database invariant', () => {
+    const hasFullChat = (chaId: string, chatId: string) => chaId === 'char-1' && chatId === 'chat-1'
+
+    it('canonicalizes only a missing characters field for a brand-new database', () => {
+        const emptyDatabase = canonicalizeStrippedDatabase({})
+        expect(emptyDatabase).toEqual({ characters: [] })
+        expect(validateStrippedDatabase(emptyDatabase, () => false)).toBe(true)
+        expect(canonicalizeStrippedDatabase({ format: 1 })).toEqual({ format: 1, characters: [] })
+
+        for (const malformed of [
+            { characters: null },
+            { characters: {} },
+            { characters: 'invalid' },
+        ]) {
+            const canonical = canonicalizeStrippedDatabase(malformed)
+            expect(canonical).toBe(malformed)
+            expect(() => validateStrippedDatabase(canonical, () => false)).toThrow(/characters must be an array/i)
+        }
+    })
+
+    it('accepts canonical stubs backed by the full chat store', () => {
+        expect(validateStrippedDatabase(strippedDatabase(), hasFullChat)).toBe(true)
+    })
+
+    it('rejects duplicate or empty character and chat identities', () => {
+        const duplicateCharacter = strippedDatabase()
+        duplicateCharacter.characters.push(structuredClone(duplicateCharacter.characters[0]))
+        expect(() => validateStrippedDatabase(duplicateCharacter, hasFullChat)).toThrow(/duplicate chaId/i)
+
+        const duplicateChat = strippedDatabase()
+        duplicateChat.characters[0].chats.push(structuredClone(duplicateChat.characters[0].chats[0]))
+        expect(() => validateStrippedDatabase(duplicateChat, hasFullChat)).toThrow(/duplicate chat id/i)
+
+        const emptyId = strippedDatabase()
+        emptyId.characters[0].chats[0].id = ''
+        expect(() => validateStrippedDatabase(emptyId, hasFullChat)).toThrow(/empty id/i)
+
+        const blankCharacterId = strippedDatabase()
+        blankCharacterId.characters[0].chaId = '   '
+        expect(() => validateStrippedDatabase(blankCharacterId, hasFullChat)).toThrow(/empty chaId/i)
+    })
+
+    it('rejects payload-bearing, noncanonical, or orphaned stubs', () => {
+        const payload = strippedDatabase()
+        Object.assign(payload.characters[0].chats[0], { message: [] })
+        expect(() => validateStrippedDatabase(payload, hasFullChat)).toThrow(/canonical stub/i)
+
+        const leakedField = strippedDatabase()
+        Object.assign(leakedField.characters[0].chats[0], { scriptstate: {} })
+        expect(() => validateStrippedDatabase(leakedField, hasFullChat)).toThrow(/non-stub fields/i)
+
+        expect(() => validateStrippedDatabase(strippedDatabase(), () => false)).toThrow(/no full-chat payload/i)
+    })
+})

--- a/server/node/chatWriteJournal.cjs
+++ b/server/node/chatWriteJournal.cjs
@@ -1,0 +1,170 @@
+'use strict';
+
+const DEFAULT_PREFIX = 'internal/chat-write/v1/';
+
+function pairKey(chaId, chatId) {
+    return JSON.stringify([chaId, chatId]);
+}
+
+function storageKey(prefix, chaId, chatId) {
+    return `${prefix}${Buffer.from(pairKey(chaId, chatId), 'utf8').toString('base64url')}`;
+}
+
+function hasChatMetadata(database, chaId, chatId) {
+    if (!Array.isArray(database?.characters)) return false;
+    const character = database.characters.find((entry) => entry?.chaId === chaId);
+    return Array.isArray(character?.chats)
+        && character.chats.some((chat) => chat?.id === chatId);
+}
+
+/**
+ * A small durable write-ahead journal for chat payloads.
+ *
+ * Chat content is saved before its database.bin stub. The journal makes the
+ * server's success response durable without prematurely changing the stripped
+ * database (which would invalidate the client's patch hash). Records for a new
+ * chat remain until a database persist contains its stub; records for an
+ * existing chat can be cleared after the next database persist, including when
+ * that persist intentionally deletes the chat.
+ */
+function createChatWriteJournal({
+    kvGet,
+    kvSet,
+    kvDel,
+    kvList,
+    encode,
+    decode,
+    prefix = DEFAULT_PREFIX,
+    onInvalid = () => {},
+}) {
+    const records = new Map();
+    let loadPromise = null;
+    let loaded = false;
+
+    function isValidRecord(record) {
+        return record
+            && record.version === 1
+            && typeof record.chaId === 'string'
+            && record.chaId.length > 0
+            && typeof record.chatId === 'string'
+            && record.chatId.length > 0
+            && record.chat
+            && typeof record.chat === 'object'
+            && record.chat.id === record.chatId
+            && Array.isArray(record.chat.message)
+            && typeof record.awaitingMetadata === 'boolean';
+    }
+
+    async function ensureLoaded() {
+        if (loaded) return;
+        if (loadPromise) return loadPromise;
+        loadPromise = (async () => {
+            for (const key of kvList(prefix)) {
+                try {
+                    const value = kvGet(key);
+                    if (!value) continue;
+                    const record = await decode(value);
+                    if (!isValidRecord(record)) {
+                        onInvalid(key, new Error('invalid chat write journal record'));
+                        continue;
+                    }
+                    records.set(pairKey(record.chaId, record.chatId), {
+                        ...record,
+                        storageKey: key,
+                    });
+                } catch (error) {
+                    onInvalid(key, error);
+                }
+            }
+            loaded = true;
+        })();
+        try {
+            await loadPromise;
+        } finally {
+            loadPromise = null;
+        }
+    }
+
+    async function stage(chaId, chatId, chat, { awaitingMetadata }) {
+        await ensureLoaded();
+        const key = pairKey(chaId, chatId);
+        const previous = records.get(key);
+        const record = {
+            version: 1,
+            chaId,
+            chatId,
+            chat,
+            // Once a payload is waiting for its first stub, later updates must
+            // keep waiting until that stub is durably committed.
+            awaitingMetadata: previous?.awaitingMetadata === true || awaitingMetadata === true,
+            updatedAt: Date.now(),
+        };
+        if (!isValidRecord(record)) {
+            throw new Error('Refusing to journal an invalid chat payload');
+        }
+        const keyOnDisk = storageKey(prefix, chaId, chatId);
+        // Persist before publishing to memory or acknowledging the request.
+        kvSet(keyOnDisk, Buffer.from(encode(record)));
+        records.set(key, { ...record, storageKey: keyOnDisk });
+    }
+
+    async function restoreInto(chatStore) {
+        await ensureLoaded();
+        for (const record of records.values()) {
+            if (!chatStore.has(record.chaId)) {
+                chatStore.set(record.chaId, new Map());
+            }
+            // Journal content is newer than database.bin (or byte-identical if
+            // the process died after the DB commit but before journal cleanup).
+            chatStore.get(record.chaId).set(record.chatId, record.chat);
+        }
+    }
+
+    async function clearAfterDatabasePersist(strippedDatabase) {
+        await ensureLoaded();
+        for (const [key, record] of [...records.entries()]) {
+            const metadataCommitted = hasChatMetadata(
+                strippedDatabase,
+                record.chaId,
+                record.chatId,
+            );
+            if (record.awaitingMetadata && !metadataCommitted) continue;
+            try {
+                kvDel(record.storageKey);
+                records.delete(key);
+            } catch (error) {
+                // Keeping a byte-identical journal record is safe. It will be
+                // replayed on restart and cleanup can succeed on a later flush.
+                onInvalid(record.storageKey, error);
+            }
+        }
+    }
+
+    async function isAwaitingMetadata(chaId, chatId) {
+        await ensureLoaded();
+        return records.get(pairKey(chaId, chatId))?.awaitingMetadata === true;
+    }
+
+    function resetMemory() {
+        records.clear();
+        loaded = false;
+        loadPromise = null;
+    }
+
+    return {
+        prefix,
+        ensureLoaded,
+        stage,
+        restoreInto,
+        clearAfterDatabasePersist,
+        isAwaitingMetadata,
+        resetMemory,
+        size: () => records.size,
+    };
+}
+
+module.exports = {
+    DEFAULT_PREFIX,
+    createChatWriteJournal,
+    hasChatMetadata,
+};

--- a/server/node/chatWriteJournal.test.ts
+++ b/server/node/chatWriteJournal.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import journalPackage from './chatWriteJournal.cjs'
+import deltaPackage from './chatDelta.cjs'
+
+const { createChatWriteJournal } = journalPackage as {
+    createChatWriteJournal: (options: any) => {
+        prefix: string
+        stage: (chaId: string, chatId: string, chat: any, options: { awaitingMetadata: boolean }) => Promise<void>
+        restoreInto: (store: Map<string, Map<string, any>>) => Promise<void>
+        clearAfterDatabasePersist: (database: any) => Promise<void>
+        isAwaitingMetadata: (chaId: string, chatId: string) => Promise<boolean>
+        size: () => number
+    }
+}
+const { validateStrippedDatabase } = deltaPackage as {
+    validateStrippedDatabase: (
+        database: any,
+        hasFullChat: (chaId: string, chatId: string) => boolean,
+    ) => boolean
+}
+
+function makeHarness(kv = new Map<string, Buffer>()) {
+    const journal = createChatWriteJournal({
+        kvGet: (key: string) => kv.get(key) ?? null,
+        kvSet: (key: string, value: Uint8Array) => kv.set(key, Buffer.from(value)),
+        kvDel: (key: string) => kv.delete(key),
+        kvList: (prefix: string) => [...kv.keys()].filter(key => key.startsWith(prefix)),
+        encode: (value: unknown) => Buffer.from(JSON.stringify(value), 'utf8'),
+        decode: async (value: Uint8Array) => JSON.parse(Buffer.from(value).toString('utf8')),
+    })
+    return { journal, kv }
+}
+
+function chat(data = 'answer') {
+    return {
+        id: 'chat-new',
+        name: 'New chat',
+        message: [{ role: 'char', data }],
+        localLore: [],
+    }
+}
+
+function databaseWithChats(chats: any[]) {
+    return {
+        characters: [{
+            chaId: 'char-1',
+            chats,
+        }],
+    }
+}
+
+describe('durable chat write journal', () => {
+    it('preserves an ACKed new chat across a stub-less flush and process restart', async () => {
+        const { journal, kv } = makeHarness()
+        await journal.stage('char-1', 'chat-new', chat(), { awaitingMetadata: true })
+
+        // The 5-second DB flush still has the old stripped DB. It must not
+        // retire the only durable copy of the newly-created chat.
+        await journal.clearAfterDatabasePersist(databaseWithChats([]))
+        expect(journal.size()).toBe(1)
+        expect(kv.size).toBe(1)
+
+        // Simulate a process restart after that flush.
+        const restarted = makeHarness(kv).journal
+        const restoredStore = new Map<string, Map<string, any>>()
+        await restarted.restoreInto(restoredStore)
+        expect(restoredStore.get('char-1')?.get('chat-new')).toEqual(chat())
+
+        // The later database patch can now add the stub: invariant validation
+        // sees the replayed payload instead of rejecting it as an orphan.
+        const withStub = databaseWithChats([
+            { id: 'chat-new', name: 'New chat', _stub: true },
+        ])
+        expect(validateStrippedDatabase(
+            withStub,
+            (chaId, chatId) => !!restoredStore.get(chaId)?.get(chatId),
+        )).toBe(true)
+
+        await restarted.clearAfterDatabasePersist(withStub)
+        expect(restarted.size()).toBe(0)
+        expect(kv.size).toBe(0)
+    })
+
+    it('keeps awaiting-metadata state across repeated writes to the new chat', async () => {
+        const { journal } = makeHarness()
+        await journal.stage('char-1', 'chat-new', chat('first'), { awaitingMetadata: true })
+        await journal.stage('char-1', 'chat-new', chat('second'), { awaitingMetadata: false })
+
+        expect(await journal.isAwaitingMetadata('char-1', 'chat-new')).toBe(true)
+        const restoredStore = new Map<string, Map<string, any>>()
+        await journal.restoreInto(restoredStore)
+        expect(restoredStore.get('char-1')?.get('chat-new')?.message[0].data).toBe('second')
+    })
+
+    it('clears an existing-chat write after a durable DB persist even when deletion wins', async () => {
+        const { journal, kv } = makeHarness()
+        await journal.stage('char-1', 'chat-new', chat('updated'), { awaitingMetadata: false })
+
+        // A concurrent metadata save intentionally deleted this existing chat.
+        // Its old journal must not resurrect it on a later ID reuse.
+        await journal.clearAfterDatabasePersist(databaseWithChats([]))
+        expect(journal.size()).toBe(0)
+        expect(kv.size).toBe(0)
+    })
+
+    it('replays the acknowledged journal value over an older database value', async () => {
+        const { journal } = makeHarness()
+        await journal.stage('char-1', 'chat-new', chat('newer'), { awaitingMetadata: false })
+        const store = new Map([
+            ['char-1', new Map([['chat-new', chat('older')]])],
+        ])
+
+        await journal.restoreInto(store)
+        expect(store.get('char-1')?.get('chat-new')?.message[0].data).toBe('newer')
+    })
+})

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -32,6 +32,18 @@ const {
 } = require('./logs.cjs');
 const { applyPatch } = require('fast-json-patch');
 const { decodeRisuSave, encodeRisuSaveLegacy, calculateHash, normalizeJSON, hasRemoteBlocks } = require('./utils.cjs');
+const {
+    chatRevision,
+    evaluateChatRevisionPrecondition,
+    evaluateFullChatWritePrecondition,
+    applyChatDelta,
+    canonicalizeStrippedDatabase,
+    validateStrippedDatabase,
+} = require('./chatDelta.cjs');
+const {
+    DEFAULT_PREFIX: CHAT_WRITE_JOURNAL_PREFIX,
+    createChatWriteJournal,
+} = require('./chatWriteJournal.cjs');
 const { spawn, execSync } = require('child_process');
 const os = require('os');
 const { Readable, Transform } = require('stream');
@@ -54,10 +66,28 @@ const enablePatchSync = true;
 let dbCache = {};
 let saveTimers = {};
 const SAVE_INTERVAL = 5000;
+const CHAT_DELTA_MAX_BYTES = 2 * 1024 * 1024;
 let fullChatStore = null; // Map<chaId, Map<chatId, chatObject>> — lazy-initialized
+let chatStoreInitPromise = null;
+let chatStoreGeneration = 0;
+
+const chatWriteJournal = createChatWriteJournal({
+    kvGet,
+    kvSet,
+    kvDel,
+    kvList,
+    encode: encodeRisuSaveLegacy,
+    decode: decodeRisuSave,
+    onInvalid: (key, error) => {
+        logger.warn(`[ChatJournal] Could not process ${key}:`, error?.message || error);
+    },
+});
 
 // ETag for database.bin
 let dbEtag = null;
+// Encoded stubs-only database sent to browsers. Keeping it alongside dbCache
+// lets an unchanged reload return 304 without decoding the full on-disk DB.
+let dbEncodedCache = null;
 
 function computeBufferEtag(buffer) {
     return nodeCrypto.createHash('md5').update(buffer).digest('hex');
@@ -65,6 +95,26 @@ function computeBufferEtag(buffer) {
 
 function computeDatabaseEtagFromObject(databaseObject) {
     return computeBufferEtag(Buffer.from(encodeRisuSaveLegacy(databaseObject)));
+}
+
+function quotedEtag(etag) {
+    return `"${etag}"`;
+}
+
+function requestEtagMatches(header, etag, { allowWeak = true } = {}) {
+    if (!header || !etag) return false;
+    return String(header).split(',').some((candidate) => {
+        const trimmed = candidate.trim();
+        if (!allowWeak && /^W\//.test(trimmed)) return false;
+        const normalized = trimmed.replace(/^W\//, '');
+        return normalized === '*' || normalized === etag || normalized === quotedEtag(etag);
+    });
+}
+
+function setRevisionHeaders(res, revision, legacyHeader) {
+    if (!revision) return;
+    res.setHeader('ETag', quotedEtag(revision));
+    if (legacyHeader) res.setHeader(legacyHeader, revision);
 }
 
 let storageOperationQueue = Promise.resolve();
@@ -75,6 +125,22 @@ function queueStorageOperation(operation) {
 }
 
 const DB_HEX_KEY = Buffer.from('database/database.bin', 'utf-8').toString('hex');
+
+function cacheStrippedDatabase(strippedDb, encoded = null) {
+    const encodedBuffer = encoded
+        ? Buffer.from(encoded)
+        : Buffer.from(encodeRisuSaveLegacy(strippedDb));
+    dbCache[DB_HEX_KEY] = strippedDb;
+    dbEncodedCache = encodedBuffer;
+    dbEtag = computeBufferEtag(encodedBuffer);
+    return encodedBuffer;
+}
+
+function invalidateStrippedDatabaseCache() {
+    delete dbCache[DB_HEX_KEY];
+    dbEncodedCache = null;
+    dbEtag = null;
+}
 
 // ─── Persist failure tracking (Stage 1 visibility) ───────────────────────────
 // Debounced persist runs in setTimeout, so failures cannot be returned in the
@@ -217,29 +283,19 @@ async function flushPendingDb() {
     if (saveTimers[DB_HEX_KEY]) {
         clearTimeout(saveTimers[DB_HEX_KEY]);
         delete saveTimers[DB_HEX_KEY];
-        if (dbCache[DB_HEX_KEY]) {
-            await persistDbCacheWithChats(DB_HEX_KEY, 'database/database.bin');
-        } else if (fullChatStore && fullChatStore.size > 0) {
-            // No stripped cache but chat store has data — merge and persist directly
-            const raw = kvGet('database/database.bin');
-            if (raw) {
-                const dbObj = normalizeJSON(await decodeRisuSave(raw));
-                const fullDb = reassembleFullDb(stripChatsFromDb(dbObj));
-                kvSet('database/database.bin', Buffer.from(encodeRisuSaveLegacy(fullDb)));
-            }
-        }
+        await persistCurrentChatStore();
         createBackupAndRotate();
     }
 }
 
 function invalidateDbCache() {
-    delete dbCache[DB_HEX_KEY];
+    chatStoreGeneration += 1;
+    invalidateStrippedDatabaseCache();
     fullChatStore = null;
     if (saveTimers[DB_HEX_KEY]) {
         clearTimeout(saveTimers[DB_HEX_KEY]);
         delete saveTimers[DB_HEX_KEY];
     }
-    dbEtag = null;
 }
 
 // ─── Chat runtime lazy load helpers ─────────────────────────────────────────
@@ -360,9 +416,14 @@ function chatToStub(chat) {
  * Strip the `_stub` flag in place so subsequent reassemble passes don't
  * reproduce the hybrid on disk.
  */
-function initChatStore(dbObj) {
-    fullChatStore = new Map();
-    if (!dbObj?.characters) return;
+async function initChatStore(dbObj) {
+    const generation = chatStoreGeneration;
+    const nextChatStore = new Map();
+    if (!dbObj?.characters) {
+        await chatWriteJournal.restoreInto(nextChatStore);
+        if (generation === chatStoreGeneration) fullChatStore = nextChatStore;
+        return;
+    }
     for (const char of dbObj.characters) {
         if (!char?.chaId || !char.chats) continue;
         const charChats = new Map();
@@ -382,9 +443,14 @@ function initChatStore(dbObj) {
             charChats.set(chat.id, chat);
         }
         if (charChats.size > 0) {
-            fullChatStore.set(char.chaId, charChats);
+            nextChatStore.set(char.chaId, charChats);
         }
     }
+    // Replay durable, acknowledged chat writes after the database snapshot.
+    // This includes a newly-created chat whose database stub has not arrived
+    // yet and an existing chat whose debounced DB flush had not completed.
+    await chatWriteJournal.restoreInto(nextChatStore);
+    if (generation === chatStoreGeneration) fullChatStore = nextChatStore;
 }
 
 /**
@@ -538,7 +604,6 @@ async function migrateRemoteBlocksIfNeeded() {
     // Reset in-memory caches whose contents were derived from the pre-migration
     // bytes — next reader recomputes from the migrated database.bin.
     invalidateDbCache();
-    dbEtag = null;
 
     const characterCount = Array.isArray(dbObj.characters) ? dbObj.characters.length : 0;
     logger.info(`[Migration] Remote-block migration complete. Inlined ${characterCount} character(s); pre-migration backup at ${backupKey}`);
@@ -549,19 +614,35 @@ async function migrateRemoteBlocksIfNeeded() {
  * Ensure fullChatStore is initialized. Loads from disk if needed.
  */
 async function ensureChatStore() {
-    if (fullChatStore) return;
+    while (!fullChatStore) {
+        if (!chatStoreInitPromise) {
+            const generation = chatStoreGeneration;
+            chatStoreInitPromise = (async () => {
     // Run remote-block migration first so the decode below sees an inline DB.
     // Idempotent — skipped on every subsequent call.
-    await migrateRemoteBlocksIfNeeded();
-    const raw = kvGet('database/database.bin');
-    if (!raw) {
-        fullChatStore = new Map();
-        return;
+                await migrateRemoteBlocksIfNeeded();
+                const raw = kvGet('database/database.bin');
+                if (!raw) {
+                    const emptyStore = new Map();
+                    await chatWriteJournal.restoreInto(emptyStore);
+                    if (generation === chatStoreGeneration) fullChatStore = emptyStore;
+                    return;
+                }
+                const dbObj = await decodeDatabaseWithPersistentChatIds(raw, {
+                    createBackup: true,
+                });
+                if (generation === chatStoreGeneration) {
+                    await initChatStore(dbObj);
+                }
+            })();
+        }
+        const pending = chatStoreInitPromise;
+        try {
+            await pending;
+        } finally {
+            if (chatStoreInitPromise === pending) chatStoreInitPromise = null;
+        }
     }
-    const dbObj = await decodeDatabaseWithPersistentChatIds(raw, {
-        createBackup: true,
-    });
-    initChatStore(dbObj);
 }
 
 // Stub metadata fields a JSON Patch may legitimately touch on a `chats[i]`
@@ -693,7 +774,7 @@ async function persistDbCacheWithChats(filePath, decodedKey) {
                 + `would silently strip messages on disk. sample=[${sample}]`
             );
             recordPersistFailure(err, 'persistDbCacheWithChats:stub-flag-loss');
-            delete dbCache[filePath];
+            invalidateStrippedDatabaseCache();
             throw err;
         }
     }
@@ -709,14 +790,59 @@ async function persistDbCacheWithChats(filePath, decodedKey) {
         }
         throw err;
     }
+    if (decodedKey === 'database/database.bin') {
+        // The database is durable now. Existing-chat journal entries and new
+        // chats whose stubs are present can be retired; a new chat still
+        // waiting for its stub remains replayable across flushes/restarts.
+        await chatWriteJournal.clearAfterDatabasePersist(strippedDb);
+    }
     // Refresh fullChatStore from the persisted snapshot so subsequent
     // /api/chat-content GETs return the same metadata (folderId, modules)
     // that just hit disk. Without this, PATCH-only clears of stub fields
     // leave fullChatStore holding stale fullChat objects, and hydration
     // would resurrect the cleared values until the next /api/read.
     if (decodedKey === 'database/database.bin') {
-        initChatStore(fullDb);
+        await initChatStore(fullDb);
     }
+}
+
+async function persistCurrentChatStore() {
+    if (!dbCache[DB_HEX_KEY]) {
+        const raw = kvGet('database/database.bin');
+        if (!raw) return;
+        const dbObj = normalizeJSON(await decodeRisuSave(raw));
+        cacheStrippedDatabase(normalizeJSON(stripChatsFromDb(dbObj)));
+    }
+    await persistDbCacheWithChats(DB_HEX_KEY, 'database/database.bin');
+}
+
+function scheduleChatStorePersist() {
+    if (saveTimers[DB_HEX_KEY]) clearTimeout(saveTimers[DB_HEX_KEY]);
+    const timer = setTimeout(() => {
+        void queueStorageOperation(async () => {
+            // A read/flush may have drained this timer while its callback was
+            // waiting for the storage queue. Do not persist a stale generation.
+            if (saveTimers[DB_HEX_KEY] !== timer) return;
+            try {
+                await persistCurrentChatStore();
+                clearPersistFailure();
+                try {
+                    createBackupAndRotate();
+                } catch (backupErr) {
+                    logger.warn('[ChatContent] Backup rotation failed:', backupErr);
+                }
+            } catch (error) {
+                logger.error('[ChatContent] Error persisting chat:', error);
+                recordPersistFailure(error, 'chat-content');
+            } finally {
+                if (saveTimers[DB_HEX_KEY] === timer) delete saveTimers[DB_HEX_KEY];
+            }
+        }).catch((error) => {
+            logger.error('[ChatContent] Storage queue failed:', error);
+            recordPersistFailure(error, 'chat-content');
+        });
+    }, SAVE_INTERVAL);
+    saveTimers[DB_HEX_KEY] = timer;
 }
 
 function shouldCompress(req, res) {
@@ -762,7 +888,13 @@ app.use('/assets', express.static(path.join(process.cwd(), 'dist/assets'), {
     immutable: true,
 }));
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false, maxAge: 0}));
-app.use(express.json({ limit: '100mb' }));
+const defaultJsonParser = express.json({ limit: '100mb' });
+const chatDeltaJsonParser = express.json({ limit: CHAT_DELTA_MAX_BYTES });
+app.use((req, res, next) => {
+    const isChatDelta = req.method === 'POST'
+        && /^\/api\/chat-content\/[^/]+\/[^/]+\/patch$/.test(req.path);
+    return (isChatDelta ? chatDeltaJsonParser : defaultJsonParser)(req, res, next);
+});
 app.use((req, res, next) => {
     // Skip express.raw() for backup import — it must stream, not buffer into memory
     if (req.path === '/api/backup/import') return next();
@@ -2223,6 +2355,8 @@ async function importBackupFromSource(dataSource, { maxBytes = 0, totalBytes = 0
     // avoids a contamination regression if that ever changes (upstream sync,
     // plugin-generated buffers, etc.).
     kvDelPrefix('remotes/');
+    kvDelPrefix(CHAT_WRITE_JOURNAL_PREFIX);
+    chatWriteJournal.resetMemory();
     // Allow remote-block migration to re-evaluate against the new database.bin.
     // (.bin backups themselves never carry REMOTE blocks — legacy msgpack
     // format only — but a fresh import is a clear "data changed" signal.)
@@ -2406,7 +2540,7 @@ async function importBackupFromSource(dataSource, { maxBytes = 0, totalBytes = 0
             migrationResult: migration,
         });
         coldStorageFailed = migration.coldStorageFailed || 0;
-        initChatStore(dbObj);
+        await initChatStore(dbObj);
     }
 
     try {
@@ -3273,9 +3407,21 @@ app.get('/api/read', async (req, res, next) => {
     }
     try {
         const key = Buffer.from(filePath, 'hex').toString('utf-8');
+        const readOperation = async () => {
         // Flush pending patches before reading database.bin
         if (key === 'database/database.bin') {
             await flushPendingDb();
+            // Allow a private cached copy, but require validation so startup can
+            // take the in-memory 304 fast path without serving stale data.
+            res.setHeader('Cache-Control', 'private, no-cache');
+            if (dbEncodedCache && dbEtag) {
+                setRevisionHeaders(res, dbEtag, 'x-db-etag');
+                if (requestEtagMatches(req.headers['if-none-match'], dbEtag)) {
+                    return res.status(304).end();
+                }
+                res.setHeader('Content-Type', 'application/octet-stream');
+                return res.send(dbEncodedCache);
+            }
         }
         let value = null;
         if (key.startsWith('inlay/')) {
@@ -3295,25 +3441,34 @@ app.get('/api/read', async (req, res, next) => {
                     const dbObj = await decodeDatabaseWithPersistentChatIds(value, {
                         createBackup: true,
                     });
-                    initChatStore(dbObj);
+                    await initChatStore(dbObj);
                     const stripped = normalizeJSON(stripChatsFromDb(dbObj));
-                    // Populate dbCache so patch endpoint uses the same data
-                    dbCache[filePath] = stripped;
-                    value = Buffer.from(encodeRisuSaveLegacy(stripped));
+                    value = cacheStrippedDatabase(stripped);
                 } catch (e) {
                     // Log the Error itself (not just e.message) so logger.*
                     // tags it and the Express middleware won't re-log after next().
                     logger.error('[Read] Failed to strip chats from database.bin', e);
-                    return next(e);
+                    throw e;
                 }
-                dbEtag = computeBufferEtag(value);
-                if (req.headers['if-none-match'] === dbEtag) {
+                setRevisionHeaders(res, dbEtag, 'x-db-etag');
+                if (requestEtagMatches(req.headers['if-none-match'], dbEtag)) {
                     return res.status(304).end();
                 }
-                res.setHeader('x-db-etag', dbEtag);
             }
             res.setHeader('Content-Type', 'application/octet-stream');
             res.send(value);
+        }
+        };
+
+        // Unlike inlay and other immutable payload reads, database reads touch
+        // the shared stripped cache/full-chat store and may flush a pending
+        // debounce. Serialize that entire path with patch/write operations.
+        // flushPendingDb itself does not enqueue, so this cannot self-deadlock
+        // with /api/db/flush (which independently acquires the same queue).
+        if (key === 'database/database.bin') {
+            await queueStorageOperation(readOperation);
+        } else {
+            await readOperation();
         }
     } catch (error) {
         next(error);
@@ -3324,6 +3479,7 @@ app.get('/api/remove', async (req, res, next) => {
     if(!await checkAuth(req, res)){
         return;
     }
+    if (!checkActiveSession(req, res)) return;
     const filePath = req.headers['file-path'];
     if (!filePath) {
         res.status(400).send({ error:'File path required' });
@@ -3334,20 +3490,31 @@ app.get('/api/remove', async (req, res, next) => {
         return;
     }
     try {
-        const key = Buffer.from(filePath, 'hex').toString('utf-8');
-        if (key.startsWith('inlay/')) {
-            const id = key.slice('inlay/'.length)
-            await deleteInlayFile(id)
+        await queueStorageOperation(async () => {
+            const key = Buffer.from(filePath, 'hex').toString('utf-8');
+            if (key.startsWith('inlay/')) {
+                const id = key.slice('inlay/'.length)
+                await deleteInlayFile(id)
+                kvDel(key);
+                kvDel(`inlay_thumb/${id}`);
+                kvDel(`inlay_info/${id}`);
+                return res.send({ success: true });
+            }
+            if (key.startsWith('inlay_info/')) {
+                await fs.unlink(getInlaySidecarPath(key.slice('inlay_info/'.length))).catch(() => {});
+            }
+            if (key === 'database/database.bin' && saveTimers[DB_HEX_KEY]) {
+                clearTimeout(saveTimers[DB_HEX_KEY]);
+                delete saveTimers[DB_HEX_KEY];
+            }
             kvDel(key);
-            kvDel(`inlay_thumb/${id}`);
-            kvDel(`inlay_info/${id}`);
-            return res.send({ success: true });
-        }
-        if (key.startsWith('inlay_info/')) {
-            await fs.unlink(getInlaySidecarPath(key.slice('inlay_info/'.length))).catch(() => {});
-        }
-        kvDel(key);
-        res.send({ success: true });
+            if (key === 'database/database.bin') {
+                kvDelPrefix(CHAT_WRITE_JOURNAL_PREFIX);
+                chatWriteJournal.resetMemory();
+                invalidateDbCache();
+            }
+            res.send({ success: true });
+        });
     } catch (error) {
         next(error);
     }
@@ -3367,7 +3534,8 @@ app.get('/api/list', async (req, res, next) => {
                 ...kvList('inlay/'),
             ])];
         } else {
-            data = kvList(keyPrefix || undefined);
+            data = kvList(keyPrefix || undefined)
+                .filter(key => !key.startsWith(CHAT_WRITE_JOURNAL_PREFIX));
         }
         res.send({ success: true, content: data });
     } catch (error) {
@@ -3462,11 +3630,17 @@ app.post('/api/write', async (req, res, next) => {
     try {
         await queueStorageOperation(async () => {
             const key = Buffer.from(filePath, 'hex').toString('utf-8');
+            let incomingStrippedDb = null;
 
             // ETag conflict detection for database.bin
             if (key === 'database/database.bin') {
-                const ifMatch = req.headers['x-if-match'];
-                if (ifMatch && dbEtag && ifMatch !== dbEtag) {
+                const standardIfMatch = req.headers['if-match'];
+                const legacyIfMatch = req.headers['x-if-match'];
+                const ifMatch = standardIfMatch || legacyIfMatch;
+                const matches = standardIfMatch
+                    ? requestEtagMatches(standardIfMatch, dbEtag, { allowWeak: false })
+                    : requestEtagMatches(legacyIfMatch, dbEtag);
+                if (ifMatch && dbEtag && !matches) {
                     res.status(409).send({
                         error: 'ETag mismatch - concurrent modification detected',
                         currentEtag: dbEtag
@@ -3501,9 +3675,26 @@ app.post('/api/write', async (req, res, next) => {
             } else if (key === 'database/database.bin') {
                 // Client sends stubs-only DB — merge full chats from server before persisting
                 try {
-                    const incomingDb = await decodeRisuSave(fileContent);
+                    const incomingDb = normalizeJSON(await decodeRisuSave(fileContent));
                     await ensureChatStore();
-                    const fullDb = reassembleFullDb(incomingDb);
+                    incomingStrippedDb = canonicalizeStrippedDatabase(
+                        normalizeJSON(stripChatsFromDb(incomingDb))
+                    );
+                    try {
+                        validateStrippedDatabase(incomingStrippedDb, (chaId, chatId) => {
+                            const fullChat = fullChatStore?.get(chaId)?.get(chatId);
+                            return !!fullChat && Array.isArray(fullChat.message);
+                        });
+                    } catch (invariantError) {
+                        res.status(422).json({
+                            error: 'Write rejected: stripped database invariant failed',
+                            code: 'DB_INVARIANT_REJECTED',
+                            detail: String(invariantError?.message || invariantError),
+                            currentEtag: dbEtag,
+                        });
+                        return;
+                    }
+                    const fullDb = reassembleFullDb(incomingStrippedDb);
 
                     // Mirror the patch-persist guard (persistDbCacheWithChats):
                     // a malformed full-write payload could carry chats with
@@ -3529,9 +3720,10 @@ app.post('/api/write', async (req, res, next) => {
                     }
 
                     const mergedContent = Buffer.from(encodeRisuSaveLegacy(fullDb));
-                    // Re-init chat store from merged result
-                    initChatStore(fullDb);
                     kvSet(key, mergedContent);
+                    await chatWriteJournal.clearAfterDatabasePersist(incomingStrippedDb);
+                    // Publish the merged store only after database.bin is durable.
+                    await initChatStore(fullDb);
                 } catch (e) {
                     logger.error('[Write] Failed to merge chats into database.bin:', e.message);
                     // Do NOT write stubs-only to disk — that would permanently
@@ -3543,16 +3735,16 @@ app.post('/api/write', async (req, res, next) => {
                 kvSet(key, fileContent);
             }
 
-            // Update ETag, backup, and invalidate cache after database.bin write
+            // Keep the canonical stubs-only representation ready for the next
+            // conditional startup read.
             if (key === 'database/database.bin') {
-                delete dbCache[DB_HEX_KEY];
                 if (saveTimers[DB_HEX_KEY]) {
                     clearTimeout(saveTimers[DB_HEX_KEY]);
                     delete saveTimers[DB_HEX_KEY];
                 }
-                // ETag based on stripped version (what client sees)
-                dbEtag = computeBufferEtag(fileContent);
+                cacheStrippedDatabase(incomingStrippedDb);
                 createBackupAndRotate();
+                setRevisionHeaders(res, dbEtag, 'x-db-etag');
             }
 
             res.send({
@@ -3570,6 +3762,7 @@ app.post('/api/db/flush', sessionAuthMiddleware, async (req, res, next) => {
     try {
         await queueStorageOperation(async () => {
             await flushPendingDb();
+            setRevisionHeaders(res, dbEtag, 'x-db-etag');
             res.send({
                 success: true,
                 etag: dbEtag ?? undefined
@@ -3606,23 +3799,24 @@ app.post('/api/patch', async (req, res, next) => {
     try {
         await queueStorageOperation(async () => {
             const decodedKey = Buffer.from(filePath, 'hex').toString('utf-8');
+            const cacheKey = decodedKey === 'database/database.bin' ? DB_HEX_KEY : filePath;
 
             // Load database into memory if not already cached
             // For database.bin, cache holds the STRIPPED version (stubs only)
-            if (!dbCache[filePath]) {
+            if (!dbCache[cacheKey]) {
                 const fileContent = kvGet(decodedKey);
                 if (fileContent) {
                     const decoded = decodedKey === 'database/database.bin'
                         ? await decodeDatabaseWithPersistentChatIds(fileContent)
                         : normalizeJSON(await decodeRisuSave(fileContent));
                     if (decodedKey === 'database/database.bin') {
-                        initChatStore(decoded);
-                        dbCache[filePath] = normalizeJSON(stripChatsFromDb(decoded));
+                        await initChatStore(decoded);
+                        cacheStrippedDatabase(normalizeJSON(stripChatsFromDb(decoded)));
                     } else {
-                        dbCache[filePath] = decoded;
+                        dbCache[cacheKey] = decoded;
                     }
                 } else {
-                    dbCache[filePath] = {};
+                    dbCache[cacheKey] = {};
                 }
             }
 
@@ -3647,9 +3841,10 @@ app.post('/api/patch', async (req, res, next) => {
                 );
                 let currentEtag;
                 try {
-                    currentEtag = computeBufferEtag(Buffer.from(encodeRisuSaveLegacy(dbCache[filePath])));
-                    dbEtag = currentEtag;
+                    cacheStrippedDatabase(dbCache[cacheKey]);
+                    currentEtag = dbEtag;
                 } catch {}
+                setRevisionHeaders(res, currentEtag, 'x-db-etag');
                 res.status(409).send({
                     error: 'Patch rejected: chat-internal field ops not allowed for lazy-loaded chats',
                     code: 'CHAT_GUARD_REJECTED',
@@ -3659,15 +3854,16 @@ app.post('/api/patch', async (req, res, next) => {
                 return;
             }
 
-            const serverHash = calculateHash(dbCache[filePath]).toString(16);
+            const serverHash = calculateHash(dbCache[cacheKey]).toString(16);
 
             if (expectedHash !== serverHash) {
                 console.log(`[Patch] Hash mismatch for ${decodedKey}: expected=${expectedHash}, server=${serverHash}`);
                 let currentEtag = undefined;
                 if (decodedKey === 'database/database.bin') {
-                    currentEtag = computeBufferEtag(Buffer.from(encodeRisuSaveLegacy(dbCache[filePath])));
-                    dbEtag = currentEtag;
+                    cacheStrippedDatabase(dbCache[cacheKey]);
+                    currentEtag = dbEtag;
                 }
+                setRevisionHeaders(res, currentEtag, 'x-db-etag');
                 res.status(409).send({
                     error: 'Hash mismatch - data out of sync',
                     currentEtag
@@ -3676,27 +3872,55 @@ app.post('/api/patch', async (req, res, next) => {
             }
 
             // Apply patch to in-memory database (clone first to prevent partial mutation on failure)
-            const snapshot = JSON.parse(JSON.stringify(dbCache[filePath]));
+            const snapshot = JSON.parse(JSON.stringify(dbCache[cacheKey]));
             let result;
+            let nextDocument;
             try {
-                result = applyPatch(snapshot, patch, true);
+                result = applyPatch(snapshot, patch, true, true, true);
+                nextDocument = normalizeJSON(result.newDocument);
             } catch (patchErr) {
                 // Invalidate corrupted cache entry to force reload on next request
-                delete dbCache[filePath];
+                if (decodedKey === 'database/database.bin') {
+                    invalidateStrippedDatabaseCache();
+                } else {
+                    delete dbCache[cacheKey];
+                }
                 throw patchErr;
             }
-            dbCache[filePath] = snapshot;
+
+            if (decodedKey === 'database/database.bin') {
+                try {
+                    await ensureChatStore();
+                    validateStrippedDatabase(nextDocument, (chaId, chatId) => {
+                        const fullChat = fullChatStore?.get(chaId)?.get(chatId);
+                        return !!fullChat && Array.isArray(fullChat.message);
+                    });
+                } catch (invariantError) {
+                    cacheStrippedDatabase(dbCache[cacheKey]);
+                    setRevisionHeaders(res, dbEtag, 'x-db-etag');
+                    res.status(409).send({
+                        error: 'Patch rejected: stripped database invariant failed',
+                        code: 'DB_INVARIANT_REJECTED',
+                        detail: String(invariantError?.message || invariantError),
+                        currentEtag: dbEtag,
+                    });
+                    return;
+                }
+            }
+            dbCache[cacheKey] = nextDocument;
 
             // Schedule save to KV (debounced) — merge full chats back for database.bin
-            if (saveTimers[filePath]) {
-                clearTimeout(saveTimers[filePath]);
+            if (saveTimers[cacheKey]) {
+                clearTimeout(saveTimers[cacheKey]);
             }
-            saveTimers[filePath] = setTimeout(async () => {
+            const patchSaveTimer = setTimeout(() => {
+                void queueStorageOperation(async () => {
+                    if (saveTimers[cacheKey] !== patchSaveTimer) return;
                 try {
                     if (decodedKey === 'database/database.bin') {
-                        await persistDbCacheWithChats(filePath, decodedKey);
+                        await persistDbCacheWithChats(cacheKey, decodedKey);
                     } else {
-                        const data = Buffer.from(encodeRisuSaveLegacy(dbCache[filePath]));
+                        const data = Buffer.from(encodeRisuSaveLegacy(dbCache[cacheKey]));
                         try {
                             kvSet(decodedKey, data);
                         } catch (err) {
@@ -3720,13 +3944,19 @@ app.post('/api/patch', async (req, res, next) => {
                     logger.error(`[Patch] Error saving ${decodedKey}:`, error);
                     recordPersistFailure(error, `patch:${decodedKey}`);
                 } finally {
-                    delete saveTimers[filePath];
+                    if (saveTimers[cacheKey] === patchSaveTimer) delete saveTimers[cacheKey];
                 }
+                }).catch((error) => {
+                    logger.error(`[Patch] Storage queue failed for ${decodedKey}:`, error);
+                    recordPersistFailure(error, `patch:${decodedKey}`);
+                });
             }, SAVE_INTERVAL);
+            saveTimers[cacheKey] = patchSaveTimer;
 
             // Update ETag after successful patch (based on stripped version)
             if (decodedKey === 'database/database.bin') {
-                dbEtag = computeBufferEtag(Buffer.from(encodeRisuSaveLegacy(dbCache[filePath])));
+                cacheStrippedDatabase(dbCache[cacheKey]);
+                setRevisionHeaders(res, dbEtag, 'x-db-etag');
             }
 
             const responsePayload = {
@@ -4492,6 +4722,7 @@ function restoreColdStorageChat(chat) {
 app.get('/api/chat-content/:chaId/:chatIndex', async (req, res, next) => {
     if (!await checkAuth(req, res)) { return; }
     try {
+        await queueStorageOperation(async () => {
         const chaId = req.params.chaId;
         const chatIndex = parseInt(req.params.chatIndex, 10);
         const expectedChatId = req.headers['x-chat-id'];
@@ -4504,6 +4735,12 @@ app.get('/api/chat-content/:chaId/:chatIndex', async (req, res, next) => {
             if (chat) {
                 if (!restoreColdStorageChat(chat)) {
                     return res.status(500).json({ error: 'Cold storage restore failed' });
+                }
+                const revision = chatRevision(chat);
+                setRevisionHeaders(res, revision, 'x-chat-revision');
+                res.setHeader('Cache-Control', 'private, no-cache');
+                if (requestEtagMatches(req.headers['if-none-match'], revision)) {
+                    return res.status(304).end();
                 }
                 const encoded = Buffer.from(encodeRisuSaveLegacy(chat));
                 res.setHeader('Content-Type', 'application/octet-stream');
@@ -4529,15 +4766,92 @@ app.get('/api/chat-content/:chaId/:chatIndex', async (req, res, next) => {
         if (!restoreColdStorageChat(chat)) {
             return res.status(500).json({ error: 'Cold storage restore failed' });
         }
+        const revision = chatRevision(chat);
+        setRevisionHeaders(res, revision, 'x-chat-revision');
+        res.setHeader('Cache-Control', 'private, no-cache');
+        if (requestEtagMatches(req.headers['if-none-match'], revision)) {
+            return res.status(304).end();
+        }
         const encoded = Buffer.from(encodeRisuSaveLegacy(chat));
         res.setHeader('Content-Type', 'application/octet-stream');
         res.send(encoded);
+        });
     } catch (error) {
         next(error);
     }
 });
 
-// POST /api/chat-content/:chaId/:chatIndex — save chat content to server
+// POST /api/chat-content/:chaId/:chatIndex/patch — save an incremental chat delta
+app.post('/api/chat-content/:chaId/:chatIndex/patch', async (req, res, next) => {
+    if (!await checkAuth(req, res)) { return; }
+    if (!checkActiveSession(req, res)) return;
+    try {
+        await queueStorageOperation(async () => {
+            const chaId = req.params.chaId;
+            const expectedChatId = typeof req.headers['x-chat-id'] === 'string'
+                ? req.headers['x-chat-id']
+                : '';
+            const baseRevision = typeof req.body?.baseRevision === 'string' ? req.body.baseRevision : '';
+            const patch = req.body?.patch;
+            const payloadBytes = Buffer.byteLength(JSON.stringify(req.body || {}));
+
+            if (!expectedChatId || !baseRevision || !Array.isArray(patch)) {
+                return res.status(400).json({ error: 'Chat ID, base revision, and patch are required' });
+            }
+            if (payloadBytes > CHAT_DELTA_MAX_BYTES) {
+                return res.status(413).json({ error: 'Chat delta is too large; use full chat save' });
+            }
+
+            await ensureChatStore();
+            const chat = fullChatStore.get(chaId)?.get(expectedChatId);
+            if (!chat) {
+                return res.status(404).json({ error: 'Chat not found; use full chat save' });
+            }
+            if (!restoreColdStorageChat(chat)) {
+                return res.status(500).json({ error: 'Cold storage restore failed' });
+            }
+
+            const precondition = evaluateChatRevisionPrecondition(chat, baseRevision);
+            if (!precondition.matches) {
+                setRevisionHeaders(res, precondition.currentRevision, 'x-chat-revision');
+                return res.status(409).json({
+                    error: 'Chat revision mismatch',
+                    currentRevision: precondition.currentRevision,
+                });
+            }
+
+            let nextChat;
+            try {
+                nextChat = applyChatDelta(chat, patch, expectedChatId);
+            } catch (patchError) {
+                return res.status(400).json({
+                    error: 'Invalid chat delta',
+                    detail: String(patchError?.message || patchError),
+                });
+            }
+
+            const awaitingMetadata = await chatWriteJournal.isAwaitingMetadata(chaId, expectedChatId);
+            await chatWriteJournal.stage(chaId, expectedChatId, nextChat, {
+                awaitingMetadata,
+            });
+            fullChatStore.get(chaId).set(expectedChatId, nextChat);
+            const nextRevision = chatRevision(nextChat);
+            scheduleChatStorePersist();
+            setRevisionHeaders(res, nextRevision, 'x-chat-revision');
+            res.setHeader('x-chat-save-mode', 'delta');
+            res.json({
+                success: true,
+                revision: nextRevision,
+                appliedOperations: patch.length,
+                receivedBytes: payloadBytes,
+            });
+        });
+    } catch (error) {
+        next(error);
+    }
+});
+
+// POST /api/chat-content/:chaId/:chatIndex — save full chat content to server
 app.post('/api/chat-content/:chaId/:chatIndex', async (req, res, next) => {
     if (!await checkAuth(req, res)) { return; }
     if (!checkActiveSession(req, res)) return;
@@ -4545,7 +4859,9 @@ app.post('/api/chat-content/:chaId/:chatIndex', async (req, res, next) => {
         await queueStorageOperation(async () => {
             const chaId = req.params.chaId;
             const chatIndex = parseInt(req.params.chatIndex, 10);
-            const expectedChatId = req.headers['x-chat-id'];
+            const expectedChatId = typeof req.headers['x-chat-id'] === 'string'
+                ? req.headers['x-chat-id']
+                : '';
             let chatData;
             if (Buffer.isBuffer(req.body)) {
                 // Binary msgpack body (application/octet-stream)
@@ -4562,58 +4878,57 @@ app.post('/api/chat-content/:chaId/:chatIndex', async (req, res, next) => {
             if (!chatData || !expectedChatId) {
                 return res.status(400).json({ error: 'Chat data and x-chat-id required' });
             }
+            if (chatData.id && chatData.id !== expectedChatId) {
+                return res.status(409).json({ error: 'Chat ID mismatch' });
+            }
+            if (!Array.isArray(chatData.message)) {
+                return res.status(400).json({ error: 'Full chat payload must contain a message array' });
+            }
+            chatData.id = expectedChatId;
 
             await ensureChatStore();
 
-            // Update fullChatStore
+            const baseRevision = typeof req.headers['x-chat-base-revision'] === 'string'
+                ? req.headers['x-chat-base-revision']
+                : '';
+            const currentChat = fullChatStore.get(chaId)?.get(expectedChatId) || null;
+            const createOnly = String(req.headers['if-none-match'] || '')
+                .split(',')
+                .some(candidate => candidate.trim() === '*');
+            if (currentChat && !restoreColdStorageChat(currentChat)) {
+                return res.status(500).json({ error: 'Cold storage restore failed' });
+            }
+            const precondition = evaluateFullChatWritePrecondition(currentChat, {
+                baseRevision,
+                createOnly,
+            });
+            if (!precondition.matches) {
+                setRevisionHeaders(res, precondition.currentRevision, 'x-chat-revision');
+                return res.status(precondition.status).json({
+                    error: precondition.error,
+                    currentRevision: precondition.currentRevision,
+                });
+            }
+
+            const wasAwaitingMetadata = await chatWriteJournal.isAwaitingMetadata(
+                chaId,
+                expectedChatId,
+            );
+            await chatWriteJournal.stage(chaId, expectedChatId, chatData, {
+                awaitingMetadata: !currentChat || wasAwaitingMetadata,
+            });
+
+            // Publish only after the durable journal write succeeds.
             if (!fullChatStore.has(chaId)) {
                 fullChatStore.set(chaId, new Map());
             }
             fullChatStore.get(chaId).set(expectedChatId, chatData);
 
-            // Schedule debounced persist (reuses existing timer mechanism)
-            if (saveTimers[DB_HEX_KEY]) {
-                clearTimeout(saveTimers[DB_HEX_KEY]);
-            }
-            saveTimers[DB_HEX_KEY] = setTimeout(async () => {
-                try {
-                    // If dbCache has stripped DB, persist with merged chats
-                    if (dbCache[DB_HEX_KEY]) {
-                        await persistDbCacheWithChats(DB_HEX_KEY, 'database/database.bin');
-                    } else {
-                        // No stripped cache — load, merge, save
-                        const raw = kvGet('database/database.bin');
-                        if (raw) {
-                            const dbObj = normalizeJSON(await decodeRisuSave(raw));
-                            const fullDb = reassembleFullDb(stripChatsFromDb(dbObj));
-                            const encoded = Buffer.from(encodeRisuSaveLegacy(fullDb));
-                            try {
-                                kvSet('database/database.bin', encoded);
-                            } catch (err) {
-                                if (err && typeof err === 'object') {
-                                    try { err.attemptedSize = encoded.length; } catch {}
-                                }
-                                throw err;
-                            }
-                        }
-                    }
-                    // Persist succeeded — clear before backup so a backup-only
-                    // failure isn't attributed to data loss.
-                    clearPersistFailure();
-                    try {
-                        createBackupAndRotate();
-                    } catch (backupErr) {
-                        logger.warn('[ChatContent] Backup rotation failed:', backupErr);
-                    }
-                } catch (error) {
-                    logger.error('[ChatContent] Error persisting chat:', error);
-                    recordPersistFailure(error, 'chat-content');
-                } finally {
-                    delete saveTimers[DB_HEX_KEY];
-                }
-            }, SAVE_INTERVAL);
-
-            res.json({ success: true });
+            scheduleChatStorePersist();
+            const revision = chatRevision(chatData);
+            setRevisionHeaders(res, revision, 'x-chat-revision');
+            res.setHeader('x-chat-save-mode', 'full');
+            res.json({ success: true, revision });
         });
     } catch (error) {
         next(error);
@@ -4660,6 +4975,8 @@ function clearExistingData() {
     // stitch in stale cross-user data. Wiping here ensures only payloads
     // that arrived in this import survive.
     kvDelPrefix('remotes/');
+    kvDelPrefix(CHAT_WRITE_JOURNAL_PREFIX);
+    chatWriteJournal.resetMemory();
     // Clear remote-block migration marker — newly imported database.bin may
     // contain REMOTE blocks (it usually does, since save-folder imports
     // preserve upstream's split-character format) and we want the migration
@@ -5454,6 +5771,8 @@ app.post('/api/db/snapshots/restore', async (req, res, next) => {
             // /api/db/optimize. Without this, an in-flight save could land
             // after kvCopyValue and overwrite the restored snapshot.
             await flushPendingDb();
+            kvDelPrefix(CHAT_WRITE_JOURNAL_PREFIX);
+            chatWriteJournal.resetMemory();
             kvCopyValue(key, DB_BLOB_KEY);
             invalidateDbCache();
             // Snapshot may pre-date the remote-block migration. Clear the marker
@@ -5471,11 +5790,8 @@ app.post('/api/db/snapshots/restore', async (req, res, next) => {
                     const dbObj = await decodeDatabaseWithPersistentChatIds(raw, {
                         createBackup: false,
                     });
-                    initChatStore(dbObj);
-                    // Migration may have rewritten database.bin — etag must
-                    // reflect the post-migration bytes the next /api/read sends.
-                    const finalRaw = kvGet(DB_BLOB_KEY);
-                    if (finalRaw) dbEtag = computeBufferEtag(Buffer.from(finalRaw));
+                    await initChatStore(dbObj);
+                    cacheStrippedDatabase(normalizeJSON(stripChatsFromDb(dbObj)));
                 }
             } catch (e) {
                 logger.warn('[Snapshot restore] post-restore decode failed:', e?.message || e);

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -45,20 +45,65 @@ export async function loadData() {
                 await forageStorage.Init()
 
                 LoadingStatusState.text = "Loading Local Save File..."
-                let gotStorage: Uint8Array = await forageStorage.getItem('database/database.bin') as unknown as Uint8Array
-                LoadingStatusState.text = "Decoding Local Save File..."
-                if (checkNullish(gotStorage)) {
+                const startupLoad = await forageStorage.loadDatabaseForStartup()
+                let gotStorage: Uint8Array | null = startupLoad.bytes
+                let decodedFromCache = startupLoad.decoded
+                let databaseLoaded = false
+                if (checkNullish(gotStorage) && checkNullish(decodedFromCache)) {
                     createdFreshDatabase = true
                     gotStorage = encodeRisuSaveLegacy({})
                     await forageStorage.setItem('database/database.bin', gotStorage)
                 }
                 try {
-                    const decoded = await decodeRisuSave(gotStorage)
-                    setPatchSyncBaseline(safeStructuredClone(decoded))
+                    LoadingStatusState.text = decodedFromCache
+                        ? "Loading Cached Save..."
+                        : "Decoding Local Save File..."
+                    const decoded = decodedFromCache ?? await decodeRisuSave(gotStorage!)
+                    const syncBaseline = safeStructuredClone(decoded)
+                    setPatchSyncBaseline(syncBaseline)
                     console.log(decoded)
                     setDatabase(decoded)
+                    databaseLoaded = true
+                    if (gotStorage && !createdFreshDatabase) {
+                        // Do not block first paint on a large IndexedDB write.
+                        // Cache the canonical pre-setDatabase baseline because
+                        // setDatabase fills runtime defaults in-place.
+                        forageStorage.scheduleStartupDatabaseCache(
+                            gotStorage,
+                            syncBaseline,
+                            forageStorage.getDbEtag(),
+                        )
+                    }
                 } catch (error) {
                     console.error(error)
+                    // A cache hit is only an accelerator. If decoding/applying
+                    // it fails, clear it and retry the authoritative server
+                    // body once before considering backup files.
+                    if (startupLoad.fromCache) {
+                        try {
+                            LoadingStatusState.text = "Refreshing Local Save Cache..."
+                            await forageStorage.invalidateStartupDatabaseCache()
+                            gotStorage = await forageStorage.getItemFresh('database/database.bin') as unknown as Uint8Array
+                            decodedFromCache = null
+                            const decoded = await decodeRisuSave(gotStorage)
+                            const syncBaseline = safeStructuredClone(decoded)
+                            setPatchSyncBaseline(syncBaseline)
+                            setDatabase(decoded)
+                            databaseLoaded = true
+                            forageStorage.scheduleStartupDatabaseCache(
+                                gotStorage,
+                                syncBaseline,
+                                forageStorage.getDbEtag(),
+                            )
+                        } catch (refreshError) {
+                            console.error(refreshError)
+                        }
+                    }
+
+                    if (databaseLoaded) {
+                        // Fresh server retry recovered the startup path.
+                    }
+                    else {
                     const backups = await getDbBackups()
                     let backupLoaded = false
                     for (const backup of backups) {
@@ -74,6 +119,7 @@ export async function loadData() {
                     }
                     if (!backupLoaded) {
                         throw "Forage: Your save file is corrupted"
+                    }
                     }
                 }
 
@@ -108,10 +154,6 @@ export async function loadData() {
                     changeLanguage(mappedLanguage)
                 }
             }
-            LoadingStatusState.text = "Loading Plugins..."
-            try {
-                await loadPlugins()
-            } catch (error) { }
             try {
                 //@ts-expect-error navigator.standalone is iOS Safari non-standard property, not in Navigator interface
                 const isInStandaloneMode = (window.matchMedia('(display-mode: standalone)').matches) || (window.navigator.standalone) || document.referrer.includes('android-app://');
@@ -132,6 +174,14 @@ export async function loadData() {
                     char.chats = convertStubsToPlaceholders(char.chats)
                 }
             }
+
+            // Plugins must never observe the server-only raw stub shape. Runtime
+            // code understands placeholders and hydrates them on demand, while
+            // a plugin touching a raw stub can mistake it for an empty chat.
+            LoadingStatusState.text = "Loading Plugins..."
+            try {
+                await loadPlugins()
+            } catch (error) { }
 
             const db = getDatabase();
 

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -11,10 +11,10 @@ import { alertConfirm, alertError, alertMd, alertNormalWait, alertSelect, alertT
 import { hasher } from "./parser/parser.svelte";
 import { characterURLImport, hubURL } from "./characterCards";
 import { defaultJailbreak, defaultMainPrompt, oldJailbreak, oldMainPrompt } from "./storage/defaultPrompts";
-import { decodeRisuSave, encodeRisuSaveLegacy, findDangerousChatOps, RisuSaveEncoder, RisuSavePatcher, type toSaveType } from "./storage/risuSave";
-import { isHydrating, saveChatToServer, ensureChatHydrated, chatToStub, classifyChat } from "./storage/chatStorage";
+import { decodeRisuSave, encodeRisuSaveLegacy, findDangerousChatOps, normalizeJSON, RisuSaveEncoder, RisuSavePatcher, type toSaveType } from "./storage/risuSave";
+import { isHydrating, saveChatToServer, ensureChatHydrated, chatToStub, classifyChat, convertStubsToPlaceholders } from "./storage/chatStorage";
 import { AutoStorage } from "./storage/autoStorage";
-import { ConflictError, type PersistWarning } from "./storage/nodeStorage";
+import { ConflictError, type PatchItemResult, type PersistWarning } from "./storage/nodeStorage";
 import { supportsPatchSync } from "./platform";
 import { updateAnimationSpeed } from "./gui/animation";
 import { updateColorScheme, updateTextThemeAndCSS } from "./gui/colorscheme";
@@ -27,6 +27,7 @@ import { initMobileGesture } from "./hotkey";
 import { moduleUpdate } from "./process/modules";
 import { isLocalNetworkUrl } from "./network/localNetwork";
 import { decodeProxyJobWsChunk, formatProxyStreamErrorMessage, parseProxyJobWsEvent } from "./network/proxyJobWs";
+import { findTrackedDeletionConflict, jsonValuesEqual, mergeThreeWayValue, mergeTrackedChanges } from "./storage/conflictRebase";
 
 export const forageStorage = new AutoStorage()
 
@@ -251,7 +252,23 @@ export let requiresFullEncoderReload = $state({
 let requestImmediateSaveImpl: ((options?: {
     forceFullWrite?: boolean
 }) => Promise<void> | void) = () => {}
+let requestChatSaveImpl: ((chaId: string, chatId: string) => Promise<void> | void) = () => {}
+const pendingExplicitChats = new Map<string, [string, string]>()
+const pendingExplicitCharacters = new Set<string>()
+let markChatDirtyImpl = (chaId: string, chatId: string) => {
+    if (chaId && chatId) pendingExplicitChats.set(`${chaId}|${chatId}`, [chaId, chatId])
+}
+let markCharacterDirtyImpl = (chaId: string) => {
+    if (chaId) pendingExplicitCharacters.add(chaId)
+}
 let patchSyncBaseline: Database | null = null
+
+class ManualSaveConflictError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'ManualSaveConflictError'
+    }
+}
 
 // Surfaces server-side persist failures (Stage 1 visibility — see issues.md).
 // The same failure is re-attached on every patch response until cleared, so we
@@ -360,6 +377,19 @@ export function requestImmediateSave(options?: {
     return requestImmediateSaveImpl(options)
 }
 
+/** Explicit dirty hook for async plugin APIs that mutate an inactive chat. */
+export function requestChatSave(chaId: string, chatId: string) {
+    return requestChatSaveImpl(chaId, chatId)
+}
+
+export function markChatDirty(chaId: string, chatId: string): void {
+    markChatDirtyImpl(chaId, chatId)
+}
+
+export function markCharacterDirty(chaId: string): void {
+    markCharacterDirtyImpl(chaId)
+}
+
 export function setPatchSyncBaseline(data: Database | null) {
     patchSyncBaseline = data ? safeStructuredClone(data) as Database : null
 }
@@ -415,16 +445,63 @@ export async function saveDb() {
         pluginCustomStorage: false
     }
 
+    function queueTrackedChat(chaId: string, chatId: string) {
+        if (!chaId || !chatId) return
+        if (
+            changeTracker.chat[0]?.[0] !== chaId ||
+            changeTracker.chat[0]?.[1] !== chatId
+        ) {
+            changeTracker.chat.unshift([chaId, chatId])
+        }
+    }
+
+    function queueTrackedCharacter(chaId: string) {
+        if (!chaId) return
+        changeTracker.character = [chaId, ...changeTracker.character.filter((id) => id !== chaId)]
+    }
+
+    for (const [chaId, chatId] of pendingExplicitChats.values()) {
+        queueTrackedChat(chaId, chatId)
+    }
+    for (const chaId of pendingExplicitCharacters) {
+        queueTrackedCharacter(chaId)
+    }
+    if (pendingExplicitChats.size > 0 || pendingExplicitCharacters.size > 0) {
+        changed = true
+    }
+    pendingExplicitChats.clear()
+    pendingExplicitCharacters.clear()
+    markChatDirtyImpl = (chaId, chatId) => {
+        queueTrackedChat(chaId, chatId)
+        changed = true
+    }
+    markCharacterDirtyImpl = (chaId) => {
+        queueTrackedCharacter(chaId)
+        changed = true
+    }
+
     let encoder = new RisuSaveEncoder()
     await encoder.init(getDatabase(), {
         compression: false
     })
 
+    const toServerDatabaseShape = (database: Database): Database => {
+        const cloned = normalizeJSON(safeStructuredClone(database)) as Database
+        cloned.characters = (cloned.characters ?? []).map((character) => ({
+            ...character,
+            chats: (character.chats ?? []).map(chatToStub),
+        })) as any
+        return cloned
+    }
+
+    let lastConfirmedServerDb = patchSyncBaseline
+        ? normalizeJSON(safeStructuredClone(patchSyncBaseline)) as Database
+        : toServerDatabaseShape(getDatabase())
     let patcher = new RisuSavePatcher()
     if (supportsPatchSync) {
-        await patcher.init(patchSyncBaseline ?? getDatabase())
-        patchSyncBaseline = null
+        await patcher.init(lastConfirmedServerDb)
     }
+    patchSyncBaseline = null
 
     function hasTrackedChanges(toSave: toSaveType) {
         return !!(
@@ -440,8 +517,12 @@ export async function saveDb() {
 
     function takeTrackedChanges() {
         const toSave = safeStructuredClone(changeTracker)
-        changeTracker.character = changeTracker.character.length === 0 ? [] : [changeTracker.character[0]]
-        changeTracker.chat = changeTracker.chat.length === 0 ? [] : [changeTracker.chat[0]]
+        // These entries belong to this save attempt. Mutations that happen
+        // while it is in flight are observed by the effects below and queued
+        // again. Retaining the first entry made unrelated saves repeatedly
+        // upload the same active character/chat.
+        changeTracker.character = []
+        changeTracker.chat = []
         changeTracker.root = false
         changeTracker.botPreset = false
         changeTracker.modules = false
@@ -473,6 +554,8 @@ export async function saveDb() {
         let didInitPluginStorageEffect = false
         let didInitGeneralEffect = false
         let trackedActiveChatKey = ''
+        const streamingCheckpointAt = new Map<string, number>()
+        const STREAMING_CHECKPOINT_INTERVAL_MS = 10_000
 
         const debounceTime = 500; // 500 milliseconds
         let saveTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -490,12 +573,24 @@ export async function saveDb() {
             }, debounceTime);
         }
 
+        function queueActiveChatForSave() {
+            const activeChar = DBState?.db?.characters?.[selIdState]
+            const activeChat = activeChar?.chats?.[activeChar?.chatPage]
+            if (!activeChar?.chaId || !activeChat?.id || activeChat._placeholder) return
+            if (isHydrating(activeChar.chaId, activeChat.id)) return
+            queueTrackedChat(activeChar.chaId, activeChat.id)
+        }
+
         // Start a best-effort save immediately when the page is hidden/unloaded.
         function flushImmediate() {
             if (saveTimeout) {
                 clearTimeout(saveTimeout);
                 saveTimeout = null;
             }
+            // Streaming normally checkpoints every ten seconds. Keep the chat
+            // dirty between checkpoints so pagehide cannot omit the final
+            // partial response merely because the throttle window is active.
+            queueActiveChatForSave()
             changed = true;
             void triggerSave({
                 skipBroadcast: true,
@@ -503,8 +598,18 @@ export async function saveDb() {
             void flushServerDbKeepalive()
         }
         document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'hidden') flushImmediate();
+            if (document.visibilityState === 'hidden') {
+                flushImmediate()
+            }
+            else if (hasTrackedChanges(changeTracker)) {
+                // Resume a bounded/paused retry when the browser becomes
+                // active again, even if no new mutation occurred.
+                changed = true
+            }
         });
+        window.addEventListener('online', () => {
+            if (hasTrackedChanges(changeTracker)) changed = true
+        })
         window.addEventListener('pagehide', flushImmediate);
 
         $effect(() => {
@@ -630,12 +735,26 @@ export async function saveDb() {
                 return
             }
 
-            if (
-                changeTracker.chat[0]?.[0] !== activeChaId ||
-                changeTracker.chat[0]?.[1] !== activeChatId
-            ) {
-                changeTracker.chat.unshift([activeChaId, activeChatId])
+            // Do not upload an ever-growing response for every streamed token.
+            // A periodic checkpoint still preserves partial output if the page
+            // closes mid-generation, and the isStreaming -> false transition
+            // always schedules the final state immediately.
+            if (activeChat.isStreaming === true) {
+                // Record dirtiness immediately, but throttle the actual network
+                // save. A pagehide flush can then persist the latest tokens.
+                queueTrackedChat(activeChaId, activeChatId)
+                const now = Date.now()
+                const lastCheckpoint = streamingCheckpointAt.get(activeKey) ?? 0
+                if (now - lastCheckpoint < STREAMING_CHECKPOINT_INTERVAL_MS) {
+                    return
+                }
+                streamingCheckpointAt.set(activeKey, now)
             }
+            else {
+                streamingCheckpointAt.delete(activeKey)
+            }
+
+            queueTrackedChat(activeChaId, activeChatId)
             saveTimeoutExecute()
         })
     })
@@ -709,58 +828,91 @@ export async function saveDb() {
         }
     }
 
-    async function rebaseTrackedLocalChangesOnLatestServerDb(conflictEtag: string | null, db: Database, toSave: toSaveType) {
-        forageStorage.setDbEtag(conflictEtag ?? null)
-        const latestData = await forageStorage.getItem('database/database.bin') as unknown as Uint8Array
+    async function rebaseTrackedLocalChangesOnLatestServerDb(db: Database, toSave: toSaveType) {
+        // patchItem/full-write conflict handlers roll the patcher back before
+        // entering here, so this is the common ancestor shared by local and
+        // remote state. It must be captured before the network await.
+        const previousServerBaseline = supportsPatchSync
+            ? patcher.baselineSnapshot() as Database
+            : safeStructuredClone(lastConfirmedServerDb) as Database
+        // A conflict ETag describes the server state, not the local baseline.
+        // Force a canonical read instead of making a conditional cache read
+        // with an ETag for bytes we do not own locally.
+        const latestData = await forageStorage.getItemFresh('database/database.bin') as unknown as Uint8Array
         if (latestData && latestData.length > 0) {
-            const latestDb = await decodeRisuSave(latestData) as Database
-            const mergedDb = safeStructuredClone(latestDb) as Database
-            const localDb = safeStructuredClone(db) as Database
+            const latestDb = normalizeJSON(await decodeRisuSave(latestData)) as Database
+            const latestServerBaseline = safeStructuredClone(latestDb) as Database
+            const localDb = normalizeJSON(safeStructuredClone(db)) as Database
+            const pendingDuringSave = safeStructuredClone(changeTracker)
+            const retryChanges = mergeTrackedChanges(toSave, pendingDuringSave)
 
-            for (const key in localDb) {
-                if (
-                    key !== 'characters' && key !== 'botPresets' && key !== 'modules' &&
-                    key !== 'plugins' && key !== 'pluginCustomStorage'
-                ) {
-                    mergedDb[key] = safeStructuredClone(localDb[key])
-                }
+            // A remote deletion racing a tracked local edit is not safely
+            // auto-mergeable. Keep the live local object untouched and stop
+            // this retry cycle instead of either reviving the deletion or
+            // silently discarding the edit.
+            const deletionConflict = findTrackedDeletionConflict(
+                previousServerBaseline,
+                localDb,
+                latestDb,
+                retryChanges,
+                chatToStub,
+            )
+            if (deletionConflict) {
+                const subject = deletionConflict.scope === 'character'
+                    ? `Character ${deletionConflict.charId}`
+                    : `Chat ${deletionConflict.chatId}`
+                throw new ManualSaveConflictError(
+                    `${subject} was deleted on another session while it had local edits. ` +
+                    'Local data was kept in this tab; copy or export it before reloading.'
+                )
             }
+            const mergedDb = mergeThreeWayValue(
+                previousServerBaseline,
+                localDb,
+                latestDb,
+            ) as Database
 
-            if (toSave.botPreset) {
-                mergedDb.botPresets = safeStructuredClone(localDb.botPresets)
-                mergedDb.botPresetsId = localDb.botPresetsId
-            }
-            if (toSave.modules) {
-                mergedDb.modules = safeStructuredClone(localDb.modules)
-            }
+            // The merge can preserve an edit whose reactive effect had not run
+            // before setDatabase. Ensure the retry covers every coarse block
+            // that now differs from the new server baseline.
+            retryChanges.root = retryChanges.root || Object.keys(mergedDb).some((key) => (
+                key !== 'characters' && key !== 'botPresets' && key !== 'modules' &&
+                !jsonValuesEqual(mergedDb[key], latestDb[key])
+            ))
+            retryChanges.botPreset = retryChanges.botPreset ||
+                !jsonValuesEqual(mergedDb.botPresets, latestDb.botPresets)
+            retryChanges.modules = retryChanges.modules ||
+                !jsonValuesEqual(mergedDb.modules, latestDb.modules)
+            retryChanges.plugins = retryChanges.plugins ||
+                !jsonValuesEqual(mergedDb.plugins, latestDb.plugins)
+            retryChanges.pluginCustomStorage = retryChanges.pluginCustomStorage ||
+                !jsonValuesEqual(mergedDb.pluginCustomStorage, latestDb.pluginCustomStorage)
 
-            const trackedCharIds = new Set<string>(toSave.character.filter(Boolean))
-            for (const trackedChat of toSave.chat) {
-                if (trackedChat?.[0]) {
-                    trackedCharIds.add(trackedChat[0])
-                }
-            }
             const mergedCharacters = Array.isArray(mergedDb.characters) ? mergedDb.characters : []
-            const localCharacters = Array.isArray(localDb.characters) ? localDb.characters : []
-
-            for (const charId of trackedCharIds) {
-                const localChar = localCharacters.find((char) => char?.chaId === charId)
-                const mergedIndex = mergedCharacters.findIndex((char) => char?.chaId === charId)
-                if (localChar) {
-                    const clonedLocalChar = safeStructuredClone(localChar)
-                    if (mergedIndex >= 0) {
-                        mergedCharacters[mergedIndex] = clonedLocalChar
-                    }
-                    else {
-                        mergedCharacters.push(clonedLocalChar)
-                    }
-                }
-                else if (mergedIndex >= 0) {
-                    mergedCharacters.splice(mergedIndex, 1)
+            const latestCharacters = Array.isArray(latestDb.characters) ? latestDb.characters : []
+            const latestById = new Map(latestCharacters.map((char) => [char?.chaId, char]))
+            const mergedById = new Map(mergedCharacters.map((char) => [char?.chaId, char]))
+            for (const charId of new Set([...latestById.keys(), ...mergedById.keys()])) {
+                if (!charId) continue
+                const latestChar = latestById.get(charId)
+                const mergedChar = mergedById.get(charId)
+                const latestStubbed = latestChar
+                    ? { ...latestChar, chats: (latestChar.chats ?? []).map(chatToStub) }
+                    : undefined
+                const mergedStubbed = mergedChar
+                    ? { ...mergedChar, chats: (mergedChar.chats ?? []).map(chatToStub) }
+                    : undefined
+                if (!jsonValuesEqual(latestStubbed, mergedStubbed)) {
+                    retryChanges.character.push(charId)
                 }
             }
-            mergedDb.characters = mergedCharacters
-            const mergedBaseline = safeStructuredClone(mergedDb) as Database
+            retryChanges.character = [...new Set(retryChanges.character)]
+
+            // Runtime and plugins must see either real chats or placeholders,
+            // never the raw server-only stub representation.
+            for (const character of mergedDb.characters) {
+                character.chats = convertStubsToPlaceholders(character.chats)
+            }
             setDatabase(mergedDb)
 
             encoder = new RisuSaveEncoder()
@@ -769,10 +921,17 @@ export async function saveDb() {
             })
             if (supportsPatchSync) {
                 patcher = new RisuSavePatcher()
-                await patcher.init(mergedBaseline)
+                // The server still owns latestServerBaseline. Initializing from
+                // merged local state would make the retry hash a state the
+                // server never accepted and cause an endless 409 loop.
+                await patcher.init(latestServerBaseline)
             }
+            lastConfirmedServerDb = latestServerBaseline
+            requeueTrackedChanges(retryChanges)
         }
-        requeueTrackedChanges(toSave)
+        else {
+            requeueTrackedChanges(toSave)
+        }
         changed = true
     }
 
@@ -832,7 +991,8 @@ export async function saveDb() {
         let newEtag: string | undefined
 
         if (supportsPatchSync && !options?.forceFullWrite) {
-            const patchData = await patcher.set(db, safeStructuredClone(toSave))
+            const preparedPatch = await patcher.set(db, safeStructuredClone(toSave))
+            const { rollback: rollbackPatchBaseline, ...patchData } = preparedPatch
             // Refuse to send patches that would corrupt server-side lazy chats.
             // chatToStub strips chats to metadata before diffing, so the only
             // way these ops appear is a baseline desync. Falling through to a
@@ -841,6 +1001,9 @@ export async function saveDb() {
             // breadcrumb for tracking down the unknown root cause.
             const dangerous = findDangerousChatOps(patchData.patch)
             if (dangerous.length > 0) {
+                // The patch was never accepted, so diagnostics and any full
+                // fallback must use the last server-confirmed baseline.
+                rollbackPatchBaseline()
                 // Always log a one-line summary so production environments
                 // see enough to file a bug report. The rich dump below is
                 // gated behind a localStorage flag — chronic loops would
@@ -993,11 +1156,24 @@ export async function saveDb() {
                 }
                 // Leave saved=false so the full-write path below kicks in.
             } else {
-                const patchResult = await forageStorage.patchItem('database/database.bin', patchData)
+                let patchResult: PatchItemResult
+                try {
+                    patchResult = await forageStorage.patchItem('database/database.bin', patchData)
+                }
+                catch (error) {
+                    rollbackPatchBaseline()
+                    throw error
+                }
                 saved = patchResult.success
-                if (patchResult.etag) {
+                if (!patchResult.success) {
+                    rollbackPatchBaseline()
+                }
+                if (patchResult.success && patchResult.etag) {
                     newEtag = patchResult.etag
                     forageStorage.setDbEtag(patchResult.etag)
+                }
+                if (patchResult.success) {
+                    lastConfirmedServerDb = patcher.baselineSnapshot() as Database
                 }
                 if (patchResult.persistWarning) {
                     showPersistWarningOnce(patchResult.persistWarning)
@@ -1008,6 +1184,17 @@ export async function saveDb() {
                 if (patchResult.chatGuardRejected) {
                     console.error('[Save] Server rejected patch — chat-internal field ops detected server-side')
                     showChatGuardToastThrottled('server')
+                }
+                else if (patchResult.validationRejected) {
+                    throw new Error(
+                        `Server rejected an invalid database update: ${patchResult.error ?? 'unknown invariant failure'}`
+                    )
+                }
+                else if (patchResult.conflict) {
+                    console.warn('[Save] Patch conflict detected, rebasing tracked changes on the latest server DB...')
+                    await rebaseTrackedLocalChangesOnLatestServerDb(db, toSave)
+                    await sleep(Math.min(500 * (savetrys + 1), 3000))
+                    return 'retry'
                 }
             }
         }
@@ -1021,17 +1208,19 @@ export async function saveDb() {
             } catch (conflictErr) {
                 if (conflictErr instanceof ConflictError) {
                     console.warn('[Save] Full-write conflict detected, rebasing tracked local changes on latest server DB...')
-                    await rebaseTrackedLocalChangesOnLatestServerDb(conflictErr.currentEtag ?? null, db, toSave)
+                    await rebaseTrackedLocalChangesOnLatestServerDb(db, toSave)
                     await sleep(Math.min(500 * (savetrys + 1), 3000))
                     return 'retry'
                 }
                 throw conflictErr
             }
 
-            // Re-init patcher from the data we just wrote so both sides
-            // share the same baseline (including setDatabase defaults).
+            // Re-init the confirmed baseline from the exact encoded data that
+            // was accepted. This also keeps conflict recovery safe when patch
+            // sync is disabled but ETag-protected full writes are enabled.
+            const decodedDb = normalizeJSON(await decodeRisuSave(dbData)) as Database
+            lastConfirmedServerDb = decodedDb
             if (supportsPatchSync) {
-                const decodedDb = await decodeRisuSave(dbData)
                 await patcher.init(decodedDb)
             }
         }
@@ -1051,7 +1240,18 @@ export async function saveDb() {
         skipBroadcast?: boolean
     }) {
         if (saveInFlight) {
-            return saveInFlight
+            // Mutations queued while a save is in flight belong to the next
+            // transaction. Chain that transaction explicitly; pagehide cannot
+            // otherwise consume the current promise and leave the final dirty
+            // chat stranded in changeTracker.
+            changed = true
+            const currentSave = saveInFlight
+            return currentSave.then(async () => {
+                if (changed || hasTrackedChanges(changeTracker)) {
+                    changed = false
+                    await triggerSave(options)
+                }
+            })
         }
 
         const toSave = takeTrackedChanges()
@@ -1065,16 +1265,55 @@ export async function saveDb() {
                 const result = await persistTrackedChanges(toSave, options)
                 if (result === 'saved') {
                     savetrys = 0
+                    deferredFailureRetries = 0
+                    if (deferredRecoveryTimer) {
+                        clearTimeout(deferredRecoveryTimer)
+                        deferredRecoveryTimer = null
+                    }
                 } else if (result === 'noop' && hasTrackedChanges(toSave)) {
                     requeueTrackedChanges(toSave)
                     changed = true
                 }
+                else if (result === 'retry') {
+                    savetrys += 1
+                    if (savetrys > 4) {
+                        // The rebased state is still dirty and remains in the
+                        // tracker, but deterministic 409s must not hammer the
+                        // server forever.
+                        changed = false
+                        alertError(new Error('Saving still conflicts after five rebases. Local edits were kept; reload or resolve the other active session before retrying.'))
+                        savetrys = 0
+                    }
+                    else {
+                        changed = true
+                    }
+                }
             } catch (error) {
                 requeueTrackedChanges(toSave)
+                if (error instanceof ManualSaveConflictError) {
+                    changed = false
+                    savetrys = 0
+                    alertError(error)
+                    return
+                }
                 savetrys += 1
                 if (savetrys > 4) {
                     alertError(error)
                     savetrys = 0
+                    // Keep the dirty tracker and allow a couple of low-rate
+                    // recovery cycles for transient outages without creating
+                    // an unbounded upload loop on a persistent failure.
+                    if (deferredFailureRetries < 2) {
+                        deferredFailureRetries += 1
+                        scheduleDeferredRecovery(30_000)
+                    }
+                    else {
+                        // Persistent server/network outages must not turn a
+                        // dirty in-memory tracker into a permanent silent stop.
+                        // Retry at a low rate to avoid repeated large uploads;
+                        // `online`/visibility events above wake it sooner.
+                        scheduleDeferredRecovery(5 * 60_000)
+                    }
                 }
                 else {
                     console.error(error)
@@ -1098,7 +1337,23 @@ export async function saveDb() {
         })
     }
 
+    requestChatSaveImpl = async (chaId, chatId) => {
+        queueTrackedChat(chaId, chatId)
+        changed = true
+        await tick()
+        await triggerSave()
+    }
+
     let savetrys = 0
+    let deferredFailureRetries = 0
+    let deferredRecoveryTimer: ReturnType<typeof setTimeout> | null = null
+    function scheduleDeferredRecovery(delayMs: number) {
+        if (deferredRecoveryTimer) clearTimeout(deferredRecoveryTimer)
+        deferredRecoveryTimer = setTimeout(() => {
+            deferredRecoveryTimer = null
+            if (hasTrackedChanges(changeTracker)) changed = true
+        }, delayMs)
+    }
     while (true) {
         if (!changed) {
             await sleep(200)

--- a/src/ts/plugins/apiV3/pluginChatAccess.test.ts
+++ b/src/ts/plugins/apiV3/pluginChatAccess.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+    PluginChatAccess,
+    type PluginCharacterLike,
+    type PluginChatLike,
+    type PluginDatabaseLike,
+} from './pluginChatAccess'
+
+const fullChat = (id: string, overrides: Partial<PluginChatLike> = {}): PluginChatLike => ({
+    id,
+    message: [],
+    note: '',
+    name: id,
+    localLore: [],
+    ...overrides,
+})
+
+const placeholder = (id: string): PluginChatLike => ({
+    ...fullChat(id),
+    _placeholder: true,
+})
+
+const character = (chaId: string, chats: PluginChatLike[]): PluginCharacterLike => ({
+    chaId,
+    chats,
+})
+
+function createHarness(characters: PluginCharacterLike[]) {
+    let database: PluginDatabaseLike = { characters }
+    const hydrateChat = vi.fn(async (chats: PluginChatLike[], index: number) => {
+        const hydrated = fullChat(chats[index].id!, {
+            message: [{ role: 'user', data: 'hydrated' }],
+        })
+        chats[index] = hydrated
+        return hydrated
+    })
+    const normalizeChat = vi.fn((chat: PluginChatLike) => ({
+        note: '',
+        name: '',
+        localLore: [],
+        ...chat,
+    }))
+    const markChatDirty = vi.fn()
+    const markCharacterDirty = vi.fn()
+    const access = new PluginChatAccess({
+        getDatabase: () => database,
+        hydrateChat,
+        normalizeChat,
+        markChatDirty,
+        markCharacterDirty,
+    })
+
+    return {
+        access,
+        hydrateChat,
+        normalizeChat,
+        markChatDirty,
+        markCharacterDirty,
+        replaceDatabase: (next: PluginDatabaseLike) => { database = next },
+    }
+}
+
+describe('PluginChatAccess hydration boundary', () => {
+    test('hydrates a placeholder before returning a chat to a plugin', async () => {
+        const chats = [placeholder('chat-1')]
+        const harness = createHarness([character('char-1', chats)])
+
+        const result = await harness.access.getHydratedChatAt(0, 0)
+
+        expect(harness.hydrateChat).toHaveBeenCalledWith(chats, 0, 'char-1')
+        expect(result?._placeholder).toBeUndefined()
+        expect(result?.message).toEqual([{ role: 'user', data: 'hydrated' }])
+    })
+
+    test('does not expose a different chat that takes over the slot during hydration', async () => {
+        const chats = [placeholder('chat-1')]
+        let release!: () => void
+        const gate = new Promise<void>((resolve) => { release = resolve })
+        const hydrateChat = vi.fn(async () => {
+            await gate
+            return fullChat('chat-1')
+        })
+        const access = new PluginChatAccess({
+            getDatabase: () => database,
+            hydrateChat,
+            normalizeChat: chat => chat,
+            markChatDirty: vi.fn(),
+            markCharacterDirty: vi.fn(),
+        })
+        const database: PluginDatabaseLike = {
+            characters: [character('char-1', chats)],
+        }
+
+        const pending = access.getHydratedChatAt(0, 0)
+        chats[0] = fullChat('chat-2')
+        release()
+
+        await expect(pending).rejects.toThrow('target changed')
+    })
+
+    test('hydrates every placeholder before returning a character or database', async () => {
+        const firstChats = [placeholder('chat-1'), fullChat('chat-2')]
+        const secondChats = [placeholder('chat-3')]
+        const harness = createHarness([
+            character('char-1', firstChats),
+            character('char-2', secondChats),
+        ])
+
+        const hydratedCharacter = await harness.access.getHydratedCharacterAt(0)
+        const hydratedDatabase = await harness.access.getHydratedDatabase()
+
+        expect(hydratedCharacter?.chats?.every(chat => !chat._placeholder)).toBe(true)
+        expect(hydratedDatabase.characters?.flatMap(char => char.chats ?? [])
+            .every(chat => !chat._placeholder)).toBe(true)
+        expect(harness.hydrateChat).toHaveBeenCalledTimes(2)
+    })
+
+    test('rejects a raw stub instead of presenting it as an empty chat', async () => {
+        const harness = createHarness([character('char-1', [{
+            id: 'chat-1',
+            _stub: true,
+        }])])
+
+        await expect(harness.access.getHydratedCharacterAt(0))
+            .rejects.toThrow('unhydrated plugin chat')
+        expect(harness.hydrateChat).not.toHaveBeenCalled()
+    })
+
+    test('rejects a database snapshot if a hydrated character target is replaced', async () => {
+        const first = character('char-1', [placeholder('chat-1')])
+        const characters = [first]
+        let release!: () => void
+        const gate = new Promise<void>((resolve) => { release = resolve })
+        const database: PluginDatabaseLike = { characters }
+        const access = new PluginChatAccess({
+            getDatabase: () => database,
+            hydrateChat: async (chats, index) => {
+                await gate
+                const hydrated = fullChat(chats[index].id!)
+                chats[index] = hydrated
+                return hydrated
+            },
+            normalizeChat: chat => chat,
+            markChatDirty: vi.fn(),
+            markCharacterDirty: vi.fn(),
+        })
+
+        const pending = access.getHydratedDatabase()
+        characters[0] = character('char-1', [fullChat('chat-new')])
+        release()
+
+        await expect(pending).rejects.toThrow('character target changed')
+    })
+})
+
+describe('PluginChatAccess mutation boundary', () => {
+    test('replaces an inactive chat by stable identity and explicitly marks it dirty', async () => {
+        const chats = [fullChat('chat-1'), placeholder('chat-2')]
+        const harness = createHarness([
+            character('char-1', [fullChat('other')]),
+            character('char-2', chats),
+        ])
+
+        await harness.access.replaceChatAt(1, 1, {
+            id: 'chat-2',
+            message: [{ role: 'assistant', data: 'updated' }],
+        })
+
+        expect(chats[1].id).toBe('chat-2')
+        expect(chats[1].message).toEqual([{ role: 'assistant', data: 'updated' }])
+        expect(chats[1]._placeholder).toBeUndefined()
+        expect(harness.markChatDirty).toHaveBeenCalledWith('char-2', 'chat-2')
+        expect(harness.markCharacterDirty).toHaveBeenCalledWith('char-2')
+    })
+
+    test('does not write or queue dirty state when the chat slot changes while loading', async () => {
+        const chats = [placeholder('chat-1')]
+        let release!: () => void
+        const gate = new Promise<void>((resolve) => { release = resolve })
+        const markChatDirty = vi.fn()
+        const markCharacterDirty = vi.fn()
+        const database: PluginDatabaseLike = {
+            characters: [character('char-1', chats)],
+        }
+        const access = new PluginChatAccess({
+            getDatabase: () => database,
+            hydrateChat: async () => {
+                await gate
+                return fullChat('chat-1')
+            },
+            normalizeChat: chat => chat,
+            markChatDirty,
+            markCharacterDirty,
+        })
+
+        const pending = access.replaceChatAt(0, 0, fullChat('chat-1', {
+            message: [{ role: 'assistant', data: 'new' }],
+        }))
+        chats[0] = fullChat('chat-2')
+        release()
+
+        await expect(pending).rejects.toThrow('target changed')
+        expect(chats[0].id).toBe('chat-2')
+        expect(markChatDirty).not.toHaveBeenCalled()
+        expect(markCharacterDirty).not.toHaveBeenCalled()
+    })
+
+    test('revalidates selection before committing a current-character replacement', async () => {
+        const harness = createHarness([character('char-1', [fullChat('chat-1')])])
+
+        await expect(harness.access.replaceCharacterAt(
+            0,
+            character('char-1', [fullChat('chat-1')]),
+            () => false,
+        )).rejects.toThrow('no longer selected')
+
+        expect(harness.markCharacterDirty).not.toHaveBeenCalled()
+        expect(harness.markChatDirty).not.toHaveBeenCalled()
+    })
+
+    test('marks the character and every full replacement chat dirty', async () => {
+        const harness = createHarness([character('char-1', [placeholder('chat-1')])])
+        const replacement = character('char-1', [
+            fullChat('chat-1'),
+            fullChat('chat-2'),
+        ])
+
+        await harness.access.replaceCharacterAt(0, replacement)
+
+        expect(harness.markCharacterDirty).toHaveBeenCalledWith('char-1')
+        expect(harness.markChatDirty).toHaveBeenCalledWith('char-1', 'chat-1')
+        expect(harness.markChatDirty).toHaveBeenCalledWith('char-1', 'chat-2')
+    })
+
+    test('rejects placeholder and duplicate identities in database character writes', () => {
+        const harness = createHarness([])
+
+        expect(() => harness.access.validateCharacterCollection([
+            character('char-1', [placeholder('chat-1')]),
+        ])).toThrow('not fully hydrated')
+
+        expect(() => harness.access.validateCharacterCollection([
+            character('char-1', [fullChat('chat-1')]),
+            character('char-1', [fullChat('chat-2')]),
+        ])).toThrow('duplicate character ID')
+    })
+})

--- a/src/ts/plugins/apiV3/pluginChatAccess.ts
+++ b/src/ts/plugins/apiV3/pluginChatAccess.ts
@@ -1,0 +1,384 @@
+export type PluginChatLike = {
+    id?: string
+    message?: unknown[]
+    _placeholder?: boolean
+    _stub?: boolean
+    [key: string]: any
+}
+
+export type PluginCharacterLike = {
+    chaId?: string
+    chats?: PluginChatLike[]
+    [key: string]: any
+}
+
+export type PluginDatabaseLike = {
+    characters?: PluginCharacterLike[]
+    [key: string]: any
+}
+
+export type PluginChatAccessDependencies = {
+    getDatabase: () => PluginDatabaseLike
+    hydrateChat: (
+        chats: PluginChatLike[],
+        index: number,
+        chaId: string,
+    ) => Promise<PluginChatLike | null>
+    normalizeChat: (chat: PluginChatLike) => PluginChatLike
+    markChatDirty: (chaId: string, chatId: string) => void
+    markCharacterDirty: (chaId: string) => void
+}
+
+type CharacterTarget = {
+    database: PluginDatabaseLike
+    characters: PluginCharacterLike[]
+    key: string
+    ordinal: number
+    character: PluginCharacterLike
+}
+
+type ChatTarget = CharacterTarget & {
+    chats: PluginChatLike[]
+    chatIndex: number
+    chat: PluginChatLike
+    chatId: string
+}
+
+type CommitGuard = () => boolean
+
+const MAX_COLLECTION_HYDRATION_PASSES = 3
+
+function characterKeys(characters: PluginCharacterLike[]): string[] {
+    return Object.keys(characters)
+}
+
+/**
+ * Keeps the compatibility-facing plugin APIs from ever exposing runtime-only
+ * lazy placeholders as real empty chats. The RPC bridge already awaits every
+ * API function, so these asynchronous trust-boundary checks do not alter the
+ * plugin-side calling convention.
+ */
+export class PluginChatAccess {
+    constructor(private readonly dependencies: PluginChatAccessDependencies) {}
+
+    private resolveCharacterAt(
+        database: PluginDatabaseLike,
+        ordinal: number,
+    ): CharacterTarget | null {
+        const characters = database?.characters
+        if (!Array.isArray(characters)) return null
+
+        const key = characterKeys(characters)[ordinal]
+        if (key === undefined) return null
+        const character = (characters as any)[key] as PluginCharacterLike | undefined
+        if (!character) return null
+
+        return { database, characters, key, ordinal, character }
+    }
+
+    private characterTargetIsCurrent(target: CharacterTarget): boolean {
+        const currentDatabase = this.dependencies.getDatabase()
+        if (currentDatabase !== target.database) return false
+        if (currentDatabase.characters !== target.characters) return false
+        if (characterKeys(target.characters)[target.ordinal] !== target.key) return false
+        return (target.characters as any)[target.key] === target.character
+    }
+
+    private assertCharacterTargetIsCurrent(target: CharacterTarget): void {
+        if (!this.characterTargetIsCurrent(target)) {
+            throw new Error('The plugin character target changed while chats were loading')
+        }
+    }
+
+    private chatTargetIsCurrent(target: ChatTarget): boolean {
+        if (!this.characterTargetIsCurrent(target)) return false
+        if (target.character.chats !== target.chats) return false
+
+        const current = target.chats[target.chatIndex]
+        if (!current) return false
+        return target.chatId ? current.id === target.chatId : current === target.chat
+    }
+
+    private assertChatTargetIsCurrent(target: ChatTarget): PluginChatLike {
+        if (!this.chatTargetIsCurrent(target)) {
+            throw new Error('The plugin chat target changed while it was loading')
+        }
+        return target.chats[target.chatIndex]
+    }
+
+    private assertCharacterChatsAreHydrated(chats: PluginChatLike[]): void {
+        const unsafeIndex = chats.findIndex(chat => !chat
+            || chat._placeholder
+            || chat._stub
+            || !Array.isArray(chat.message))
+        if (unsafeIndex !== -1) {
+            throw new Error(`Refusing to expose unhydrated plugin chat ${unsafeIndex}`)
+        }
+    }
+
+    private async hydrateCharacterTarget(target: CharacterTarget): Promise<void> {
+        const chats = target.character.chats
+        if (!Array.isArray(chats) || chats.length === 0) return
+
+        const chaId = target.character.chaId
+        if (chats.some(chat => chat?._placeholder) && !chaId) {
+            throw new Error('Cannot hydrate plugin chats for a character without an ID')
+        }
+
+        for (let pass = 0; pass < MAX_COLLECTION_HYDRATION_PASSES; pass++) {
+            this.assertCharacterTargetIsCurrent(target)
+            if (target.character.chats !== chats) {
+                throw new Error('The plugin character chat list changed while it was loading')
+            }
+
+            const placeholders = chats.filter(chat => chat?._placeholder)
+            if (placeholders.length === 0) {
+                this.assertCharacterChatsAreHydrated(chats)
+                return
+            }
+
+            for (const placeholder of placeholders) {
+                this.assertCharacterTargetIsCurrent(target)
+                if (target.character.chats !== chats) {
+                    throw new Error('The plugin character chat list changed while it was loading')
+                }
+
+                const currentIndex = chats.indexOf(placeholder)
+                if (currentIndex === -1 || !chats[currentIndex]?._placeholder) continue
+
+                const hydrated = await this.dependencies.hydrateChat(chats, currentIndex, chaId!)
+                this.assertCharacterTargetIsCurrent(target)
+                if (target.character.chats !== chats) {
+                    throw new Error('The plugin character chat list changed while it was loading')
+                }
+
+                if (!hydrated && chats.includes(placeholder) && placeholder._placeholder) {
+                    throw new Error(`Plugin chat hydration failed (${chaId}/${placeholder.id ?? currentIndex})`)
+                }
+            }
+        }
+
+        if (chats.some(chat => chat?._placeholder)) {
+            throw new Error('The plugin character chat list kept changing while it was loading')
+        }
+        this.assertCharacterChatsAreHydrated(chats)
+    }
+
+    async getHydratedDatabase(): Promise<PluginDatabaseLike> {
+        const database = this.dependencies.getDatabase()
+        const characters = database?.characters
+        if (!Array.isArray(characters)) return database
+
+        const keys = characterKeys(characters)
+        const targets = keys.map((_key, ordinal) => this.resolveCharacterAt(database, ordinal))
+        for (const target of targets) {
+            if (!target) continue
+            await this.hydrateCharacterTarget(target)
+        }
+
+        if (this.dependencies.getDatabase() !== database
+            || database.characters !== characters
+            || characterKeys(characters).some((key, index) => key !== keys[index])
+            || characterKeys(characters).length !== keys.length) {
+            throw new Error('The plugin database changed while chats were loading')
+        }
+        for (const target of targets) {
+            if (target) this.assertCharacterTargetIsCurrent(target)
+        }
+        return database
+    }
+
+    async getHydratedCharacterAt(ordinal: number): Promise<PluginCharacterLike | null> {
+        const target = this.resolveCharacterAt(this.dependencies.getDatabase(), ordinal)
+        if (!target) return null
+        await this.hydrateCharacterTarget(target)
+        this.assertCharacterTargetIsCurrent(target)
+        return target.character
+    }
+
+    private async resolveHydratedChatAt(
+        characterOrdinal: number,
+        chatIndex: number,
+    ): Promise<ChatTarget | null> {
+        const target = this.resolveCharacterAt(this.dependencies.getDatabase(), characterOrdinal)
+        if (!target) return null
+
+        const chats = target.character.chats
+        if (!Array.isArray(chats)) return null
+        const chat = chats[chatIndex]
+        if (!chat) return null
+
+        const chatId = typeof chat.id === 'string' ? chat.id : ''
+        const chatTarget: ChatTarget = {
+            ...target,
+            chats,
+            chatIndex,
+            chat,
+            chatId,
+        }
+
+        if (chat._placeholder) {
+            if (!target.character.chaId || !chatId) {
+                throw new Error('Cannot hydrate a plugin chat without stable character and chat IDs')
+            }
+            const hydrated = await this.dependencies.hydrateChat(
+                chats,
+                chatIndex,
+                target.character.chaId,
+            )
+            if (!hydrated) {
+                throw new Error(`Plugin chat hydration failed (${target.character.chaId}/${chatId})`)
+            }
+        }
+
+        const current = this.assertChatTargetIsCurrent(chatTarget)
+        if (current._placeholder || current._stub || !Array.isArray(current.message)) {
+            throw new Error('Refusing to expose an unhydrated chat to a plugin')
+        }
+        return chatTarget
+    }
+
+    async getHydratedChatAt(
+        characterOrdinal: number,
+        chatIndex: number,
+    ): Promise<PluginChatLike | null> {
+        const target = await this.resolveHydratedChatAt(characterOrdinal, chatIndex)
+        return target ? target.chats[target.chatIndex] : null
+    }
+
+    async replaceChatAt(
+        characterOrdinal: number,
+        chatIndex: number,
+        incoming: PluginChatLike,
+        commitGuard: CommitGuard = () => true,
+    ): Promise<void> {
+        const target = await this.resolveHydratedChatAt(characterOrdinal, chatIndex)
+        if (!target) return
+
+        const current = this.assertChatTargetIsCurrent(target)
+        const stableChatId = current.id
+        const chaId = target.character.chaId
+        if (!chaId || !stableChatId) {
+            throw new Error('Cannot replace a plugin chat without stable character and chat IDs')
+        }
+        if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+            throw new Error('Plugin chat setter requires a chat object')
+        }
+        if (incoming._placeholder || incoming._stub || !Array.isArray(incoming.message)) {
+            throw new Error('Plugin chat setter requires a fully hydrated chat payload')
+        }
+        if (incoming.id && incoming.id !== stableChatId) {
+            throw new Error('Plugin chat setter cannot change the target chat ID')
+        }
+
+        const next = this.dependencies.normalizeChat({ ...incoming, id: stableChatId })
+        delete next._placeholder
+        delete next._stub
+
+        this.assertChatTargetIsCurrent(target)
+        if (!commitGuard()) {
+            throw new Error('The plugin chat target is no longer selected')
+        }
+        target.chats[chatIndex] = next
+        this.dependencies.markChatDirty(chaId, stableChatId)
+        this.dependencies.markCharacterDirty(chaId)
+    }
+
+    private normalizeCharacterReplacement(
+        incoming: PluginCharacterLike,
+        stableChaId: string,
+    ): PluginCharacterLike {
+        if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+            throw new Error('Plugin character setter requires a character object')
+        }
+        if (incoming.chaId && incoming.chaId !== stableChaId) {
+            throw new Error('Plugin character setter cannot change the target character ID')
+        }
+        if (!Array.isArray(incoming.chats)) {
+            throw new Error('Plugin character setter requires a chats array')
+        }
+
+        const seenChatIds = new Set<string>()
+        const chats = incoming.chats.map((chat, index) => {
+            if (!chat || typeof chat !== 'object' || Array.isArray(chat)
+                || chat._placeholder || chat._stub || !Array.isArray(chat.message)) {
+                throw new Error(`Plugin character setter chat ${index} is not fully hydrated`)
+            }
+            if (typeof chat.id !== 'string' || chat.id.length === 0) {
+                throw new Error(`Plugin character setter chat ${index} has no stable ID`)
+            }
+            if (seenChatIds.has(chat.id)) {
+                throw new Error(`Plugin character setter contains duplicate chat ID: ${chat.id}`)
+            }
+            seenChatIds.add(chat.id)
+
+            const normalized = this.dependencies.normalizeChat({ ...chat })
+            delete normalized._placeholder
+            delete normalized._stub
+            return normalized
+        })
+
+        return { ...incoming, chaId: stableChaId, chats }
+    }
+
+    async replaceCharacterAt(
+        ordinal: number,
+        incoming: PluginCharacterLike,
+        commitGuard: CommitGuard = () => true,
+    ): Promise<void> {
+        const target = this.resolveCharacterAt(this.dependencies.getDatabase(), ordinal)
+        if (!target) return
+        await this.hydrateCharacterTarget(target)
+        this.assertCharacterTargetIsCurrent(target)
+
+        const stableChaId = target.character.chaId
+        if (!stableChaId) {
+            throw new Error('Cannot replace a plugin character without a stable character ID')
+        }
+        const next = this.normalizeCharacterReplacement(incoming, stableChaId)
+
+        this.assertCharacterTargetIsCurrent(target)
+        if (!commitGuard()) {
+            throw new Error('The plugin character target is no longer selected')
+        }
+        const characters = target.characters as any
+        characters[target.key] = next
+        this.dependencies.markCharacterDirty(stableChaId)
+        for (const chat of next.chats ?? []) {
+            this.dependencies.markChatDirty(stableChaId, chat.id!)
+        }
+    }
+
+    validateCharacterCollection(characters: unknown): PluginCharacterLike[] {
+        if (!Array.isArray(characters)) {
+            throw new Error('Plugin database setter requires a characters array')
+        }
+
+        const seenCharacterIds = new Set<string>()
+        return characters.map((character, index) => {
+            const chaId = character?.chaId
+            if (typeof chaId !== 'string' || chaId.length === 0) {
+                throw new Error(`Plugin database setter character ${index} has no stable ID`)
+            }
+            if (seenCharacterIds.has(chaId)) {
+                throw new Error(`Plugin database setter contains duplicate character ID: ${chaId}`)
+            }
+            seenCharacterIds.add(chaId)
+            return this.normalizeCharacterReplacement(character, chaId)
+        })
+    }
+
+    markCharacterCollectionDirty(previous: PluginCharacterLike[], next: PluginCharacterLike[]): void {
+        const allCharacterIds = new Set<string>()
+        for (const character of [...previous, ...next]) {
+            if (character?.chaId) allCharacterIds.add(character.chaId)
+        }
+        for (const chaId of allCharacterIds) this.dependencies.markCharacterDirty(chaId)
+        for (const character of next) {
+            if (!character?.chaId) continue
+            for (const chat of character.chats ?? []) {
+                if (chat?.id) this.dependencies.markChatDirty(character.chaId, chat.id)
+            }
+        }
+    }
+}

--- a/src/ts/plugins/apiV3/v3.svelte.ts
+++ b/src/ts/plugins/apiV3/v3.svelte.ts
@@ -9,7 +9,7 @@ import { v4 } from "uuid";
 import { sleep } from "src/ts/util";
 import { alertConfirm, alertError, alertNormal } from "src/ts/alert";
 import { language } from "src/lang";
-import { checkCharOrder, forageStorage, getFetchLogs } from "src/ts/globalApi.svelte";
+import { checkCharOrder, forageStorage, getFetchLogs, markCharacterDirty, markChatDirty } from "src/ts/globalApi.svelte";
 import { changeColorScheme, updateColorScheme, updateTextThemeAndCSS, type ColorScheme } from "src/ts/gui/colorscheme";
 import { get } from "svelte/store";
 import { registerMCPModule, unregisterMCPModule } from "src/ts/process/mcp/pluginmcp";
@@ -17,6 +17,7 @@ import { getLLMCache, searchLLMCache } from "src/ts/translator/translator";
 import { hasher } from "src/ts/parser/parser.svelte";
 import { LLMFlags, LLMFormat, LLMProvider, LLMTokenizer, type LLMModel } from "src/ts/model/types";
 import { readPersistentJson, removePersistentKey, writePersistentJson } from "src/ts/storage/persistentKv";
+import { ensureChatHydrated, ensureCurrentChatReady } from "src/ts/storage/chatStorage";
 import { sendChat as processSendChat, doingChat } from "src/ts/process/index.svelte";
 import { getModelInfo } from "src/ts/model/modellist";
 import type { ModelModeExtended } from "src/ts/process/request/shared";
@@ -34,6 +35,7 @@ import {
     type AfterTTSResult,
     type TTSHookFn,
 } from "src/ts/process/ttsHooks";
+import { PluginChatAccess } from "./pluginChatAccess";
 
 /*
     V3 API for RisuAI Plugins
@@ -753,6 +755,74 @@ const authorizationHeaders = [
 const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
 
     const oldApis = getV2PluginAPIs();
+    const pluginChatAccess = new PluginChatAccess({
+        getDatabase: () => DBState.db,
+        hydrateChat: (chats, index, chaId) => ensureChatHydrated(chats as any, index, chaId) as any,
+        normalizeChat: (chat) => normalizeChat(chat as any) as any,
+        markChatDirty,
+        markCharacterDirty,
+    })
+
+    const getCurrentCharacterForPlugin = async () => {
+        const characterIndex = get(selectedCharID)
+        const character = await pluginChatAccess.getHydratedCharacterAt(characterIndex)
+        if (get(selectedCharID) !== characterIndex) {
+            throw new Error('The selected character changed while plugin data was loading')
+        }
+        return character ? $state.snapshot(character) : undefined
+    }
+
+    const setCurrentCharacterForPlugin = async (character: any) => {
+        const characterIndex = get(selectedCharID)
+        await pluginChatAccess.replaceCharacterAt(
+            characterIndex,
+            character,
+            () => get(selectedCharID) === characterIndex,
+        )
+    }
+
+    const preparePluginDatabaseWrite = async (newDb: any) => {
+        if (!newDb || typeof newDb !== 'object'
+            || !Object.prototype.hasOwnProperty.call(newDb, 'characters')) {
+            return null
+        }
+
+        const database = await pluginChatAccess.getHydratedDatabase()
+        if (database !== DBState.db) {
+            throw new Error('The plugin database target changed while chats were loading')
+        }
+
+        const previousCharacters = [...(database.characters ?? [])]
+        const nextCharacters = pluginChatAccess.validateCharacterCollection(newDb.characters)
+        return {
+            payload: { ...newDb, characters: nextCharacters },
+            previousCharacters,
+            nextCharacters,
+        }
+    }
+
+    const setPluginDatabaseLite = async (newDb: any) => {
+        const prepared = await preparePluginDatabaseWrite(newDb)
+        oldApis.setDatabaseLite(prepared?.payload ?? newDb)
+        if (prepared) {
+            pluginChatAccess.markCharacterCollectionDirty(
+                prepared.previousCharacters,
+                prepared.nextCharacters,
+            )
+        }
+    }
+
+    const setPluginDatabase = async (newDb: any) => {
+        const prepared = await preparePluginDatabaseWrite(newDb)
+        await oldApis.setDatabase(prepared?.payload ?? newDb)
+        if (prepared) {
+            pluginChatAccess.markCharacterCollectionDirty(
+                prepared.previousCharacters,
+                prepared.nextCharacters,
+            )
+        }
+    }
+
     return {
 
         //Old APIs from v2.1
@@ -789,8 +859,8 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             }
             return oldApis.nativeFetch(url, options);
         },
-        getChar: oldApis.getChar,
-        setChar: oldApis.setChar,
+        getChar: getCurrentCharacterForPlugin,
+        setChar: setCurrentCharacterForPlugin,
         addProvider: (name: string, func: (arg: PluginV2ProviderArgument, abortSignal?: AbortSignal) => Promise<{ success: boolean, content: string }>, options?: PluginV3ProviderOptions) => {
             console.warn(`[WARN] addProvider is a powerful API that can potentially be unsafe if used incorrectly. addProvider's functionality might be limited or changed in future updates to ensure security. please use other APIs if possible.`);
             let provs = get(customProviderStore)
@@ -842,8 +912,8 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             oldApis.addRisuReplacer(name, func as any);
         },
         removeRisuReplacer: oldApis.removeRisuReplacer,
-        setDatabaseLite: oldApis.setDatabaseLite,
-        setDatabase: oldApis.setDatabase,
+        setDatabaseLite: setPluginDatabaseLite,
+        setDatabase: setPluginDatabase,
         loadPlugins: oldApis.loadPlugins,
         readImage: oldApis.readImage,
         saveAsset: oldApis.saveAsset,
@@ -853,7 +923,10 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             if(!conf){
                 return null;
             }
-            const db = DBState.db
+            const shouldIncludeCharacters = includeOnly === 'all' || includeOnly.includes('characters')
+            const db = shouldIncludeCharacters
+                ? await pluginChatAccess.getHydratedDatabase()
+                : DBState.db
             let liteDB = {}
             for(const key of allowedDbKeys){
                 if(includeOnly !== 'all' && !includeOnly.includes(key)){
@@ -951,45 +1024,19 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                 }
             }
         },
-        getCharacterFromIndex: (index:number) => {
-            const db = DBState.db
-            const charIds = Object.keys(db.characters);
-            const charId = charIds[index];
-            if(charId){
-                return $state.snapshot(db.characters[charId]);
-            }
-            return null;
+        getCharacterFromIndex: async (index:number) => {
+            const character = await pluginChatAccess.getHydratedCharacterAt(index)
+            return character ? $state.snapshot(character) : null
         },
-        setCharacterToIndex: (index:number, char:any) => {
-            const db = DBState.db
-            const charIds = Object.keys(db.characters);
-            const charId = charIds[index];
-            if(charId){
-                DBState.db.characters[charId] = char
-            }
+        setCharacterToIndex: async (index:number, char:any) => {
+            await pluginChatAccess.replaceCharacterAt(index, char)
         },
-        getChatFromIndex: (characterIndex:number, chatIndex:number) => {
-            const db = DBState.db
-            const charIds = Object.keys(db.characters);
-            const charId = charIds[characterIndex];
-            if(charId){
-                const chats = db.characters[charId].chats;
-                if(chats && chats[chatIndex]){
-                    return $state.snapshot(chats[chatIndex]);
-                }
-            }
-            return null;
+        getChatFromIndex: async (characterIndex:number, chatIndex:number) => {
+            const chat = await pluginChatAccess.getHydratedChatAt(characterIndex, chatIndex)
+            return chat ? $state.snapshot(chat) : null
         },
-        setChatToIndex: (characterIndex:number, chatIndex:number, chat:any) => {
-            const db = DBState.db
-            const charIds = Object.keys(db.characters);
-            const charId = charIds[characterIndex];
-            if(charId){
-                const chats = db.characters[charId].chats;
-                if(chats && chats[chatIndex]){
-                    DBState.db.characters[charId].chats[chatIndex] = normalizeChat(chat)
-                }
-            }
+        setChatToIndex: async (characterIndex:number, chatIndex:number, chat:any) => {
+            await pluginChatAccess.replaceChatAt(characterIndex, chatIndex, chat)
         },
         getCurrentCharacterIndex: () => {
             return get(selectedCharID)
@@ -999,21 +1046,30 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
             const charId = get(selectedCharID)
             return db.characters[charId].chatPage
         },
-        getCurrentLorebookEntries: () => {
-            const charId = get(selectedCharID)
-            const char = DBState.db.characters[charId]
+        getCurrentLorebookEntries: async () => {
+            const characterIndex = get(selectedCharID)
+            const char = DBState.db.characters[characterIndex]
             if(!char){
                 return []
             }
             const page = char.chatPage
+            const expectedChatId = char.chats?.[page]?.id
+            const chat = await pluginChatAccess.getHydratedChatAt(characterIndex, page)
+            const currentCharacter = DBState.db.characters[characterIndex]
+            if (get(selectedCharID) !== characterIndex
+                || currentCharacter !== char
+                || currentCharacter.chatPage !== page
+                || currentCharacter.chats?.[page]?.id !== expectedChatId) {
+                throw new Error('The current lorebook target changed while plugin data was loading')
+            }
             const characterLore = char.globalLore ?? []
-            const chatLore = char.chats?.[page]?.localLore ?? []
+            const chatLore = chat?.localLore ?? []
             const moduleLore = getModuleLorebooks()
             return $state.snapshot(characterLore.concat(chatLore).concat(moduleLore))
         },
         //New names for character APIs, to match API naming conventions
-        getCharacter: oldApis.getChar,
-        setCharacter: oldApis.setChar,
+        getCharacter: getCurrentCharacterForPlugin,
+        setCharacter: setCurrentCharacterForPlugin,
 
         showContainer: (
             //more types may be added in future
@@ -1416,9 +1472,25 @@ const makeRisuaiAPIV3 = (iframe:HTMLIFrameElement,plugin:RisuPlugin) => {
                 throw new Error("No character selected");
             }
 
-            const chat = char.chats[char.chatPage];
+            // Lazy-loaded chats are placeholders until their payload is fetched.
+            // Appending to the placeholder loses the message because the normal
+            // send path refuses to process an unhydrated chat. Hydrate first and
+            // only mutate the real chat after that succeeds.
+            const chatPage = char.chatPage;
+            const chat = await ensureCurrentChatReady(char.chats, chatPage, char.chaId);
             if(!chat){
-                throw new Error("No active chat found");
+                throw new Error("No active chat found or the chat could not be loaded");
+            }
+            if(
+                get(selectedCharID) !== charId ||
+                DBState.db.characters[charId] !== char ||
+                char.chatPage !== chatPage ||
+                char.chats[chatPage] !== chat
+            ){
+                throw new Error("The active chat changed while it was loading");
+            }
+            if(get(doingChat)){
+                throw new Error("A chat is already in progress");
             }
 
             if(message){

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -12,6 +12,18 @@ export class AutoStorage{
     async getItem(key:string):Promise<Buffer> {
         return await this.realStorage.getItem(key)
     }
+    async getItemFresh(key:string):Promise<Buffer> {
+        return await this.realStorage.getItemFresh(key)
+    }
+    async loadDatabaseForStartup() {
+        return await this.realStorage.loadDatabaseForStartup()
+    }
+    scheduleStartupDatabaseCache(bytes: Uint8Array, decoded: any, etag?: string | null) {
+        this.realStorage.scheduleStartupDatabaseCache(bytes, decoded, etag)
+    }
+    async invalidateStartupDatabaseCache() {
+        await this.realStorage.invalidateStartupDatabaseCache()
+    }
     async keys(prefix: string = ''):Promise<string[]>{
         await this.Init()
         return await this.realStorage.keys(prefix)

--- a/src/ts/storage/chatStorage.test.ts
+++ b/src/ts/storage/chatStorage.test.ts
@@ -1,17 +1,29 @@
-import { describe, test, expect, vi } from 'vitest'
+import { afterEach, beforeEach, describe, test, expect, vi } from 'vitest'
+
+const storageMock = vi.hoisted(() => ({ realStorage: null as any }))
+const tickMock = vi.hoisted(() => vi.fn(async () => {}))
 
 // Stub out the heavy reactive modules so loading chatStorage.ts doesn't trigger
 // unrelated $effect chains that fail in a stripped-down test environment.
 // Mirror the production isChatStub semantics including the hybrid guard so
 // the chat-data-loss tests below exercise the real intent.
-vi.mock('../globalApi.svelte', () => ({ forageStorage: { realStorage: null } }))
+vi.mock('../globalApi.svelte', () => ({ forageStorage: storageMock }))
+vi.mock('svelte', () => ({ tick: tickMock }))
 vi.mock('./database.svelte', () => ({
     isChatStub: (chat: any) => chat
         && chat._stub === true
         && !Array.isArray(chat.message),
 }))
 
-const { chatToStub, stubToPlaceholder, convertStubsToPlaceholders, classifyChat } = await import('./chatStorage')
+const {
+    chatToStub,
+    stubToPlaceholder,
+    convertStubsToPlaceholders,
+    classifyChat,
+    ensureChatHydrated,
+    hydrationInFlight,
+    hydrationJustApplied,
+} = await import('./chatStorage')
 type Chat = any
 type ChatStub = any
 
@@ -213,5 +225,157 @@ describe('hybrid corruption (chat with _stub:true + message)', () => {
         expect('note' in stub).toBe(false)
         // Once stripped, the chat-data guard would see no chat-internal field
         // ops in a baseline-vs-current diff between two of these stubs.
+    })
+})
+
+describe('lazy chat hydration safety', () => {
+    const placeholder = (id = 'chat-1'): Chat => ({
+        message: [],
+        note: '',
+        name: 'placeholder',
+        localLore: [],
+        id,
+        fmIndex: -1,
+        _placeholder: true,
+    })
+    const fullChat = (id = 'chat-1'): Chat => ({
+        message: [{ role: 'user', data: 'hello' }],
+        note: '',
+        name: 'hydrated',
+        localLore: [],
+        id,
+        fmIndex: -1,
+    })
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+            callback(0)
+            return 1
+        })
+        tickMock.mockReset()
+        tickMock.mockResolvedValue(undefined)
+        hydrationInFlight.clear()
+        hydrationJustApplied.clear()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.unstubAllGlobals()
+        storageMock.realStorage = null
+    })
+
+    test('hydrates a valid matching chat payload', async () => {
+        const chats = [placeholder()]
+        const full = fullChat()
+        storageMock.realStorage = {
+            fetchChatContent: vi.fn().mockResolvedValue(full),
+        }
+
+        await expect(ensureChatHydrated(chats, 0, 'character-1')).resolves.toBe(full)
+        expect(chats[0]).toBe(full)
+        expect(hydrationInFlight.size).toBe(0)
+        expect(hydrationJustApplied.size).toBe(0)
+    })
+
+    test.each([
+        ['a mismatched id', fullChat('other-chat')],
+        ['a missing message array', { ...fullChat(), message: undefined }],
+        ['a server stub', { id: 'chat-1', name: 'stub', _stub: true }],
+    ])('rejects %s without replacing the placeholder', async (_label, payload) => {
+        const original = placeholder()
+        const chats = [original]
+        storageMock.realStorage = {
+            fetchChatContent: vi.fn().mockResolvedValue(payload),
+        }
+
+        await expect(ensureChatHydrated(chats, 0, 'character-1')).resolves.toBeNull()
+        expect(chats[0]).toBe(original)
+    })
+
+    test('uses the timer fallback when requestAnimationFrame never fires', async () => {
+        vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+        const chats = [placeholder()]
+        const full = fullChat()
+        storageMock.realStorage = {
+            fetchChatContent: vi.fn().mockResolvedValue(full),
+        }
+
+        const hydration = ensureChatHydrated(chats, 0, 'character-1')
+        await vi.advanceTimersByTimeAsync(49)
+        expect(chats[0]._placeholder).toBe(true)
+        await vi.advanceTimersByTimeAsync(1)
+
+        await expect(hydration).resolves.toBe(full)
+        expect(chats[0]).toBe(full)
+    })
+
+    test('always clears suppression flags when the Svelte tick rejects', async () => {
+        const chats = [placeholder()]
+        storageMock.realStorage = {
+            fetchChatContent: vi.fn().mockResolvedValue(fullChat()),
+        }
+        tickMock.mockRejectedValueOnce(new Error('tick failed'))
+
+        await expect(ensureChatHydrated(chats, 0, 'character-1')).rejects.toThrow('tick failed')
+        expect(hydrationInFlight.size).toBe(0)
+        expect(hydrationJustApplied.size).toBe(0)
+    })
+
+    test('does not apply an old response after the placeholder slot is replaced', async () => {
+        let resolveFetch!: (chat: Chat) => void
+        const fetchPromise = new Promise<Chat>(resolve => { resolveFetch = resolve })
+        storageMock.realStorage = {
+            fetchChatContent: vi.fn().mockReturnValue(fetchPromise),
+        }
+        const original = placeholder()
+        const replacement = placeholder()
+        const chats = [original]
+
+        const hydration = ensureChatHydrated(chats, 0, 'character-1')
+        chats[0] = replacement
+        resolveFetch(fullChat())
+
+        await expect(hydration).resolves.toBeNull()
+        expect(chats[0]).toBe(replacement)
+    })
+
+    test('rechecks deletion while waiting for the paint yield', async () => {
+        let frameCallback: FrameRequestCallback | undefined
+        vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+            frameCallback = callback
+            return 1
+        }))
+        const chats = [placeholder()]
+        storageMock.realStorage = {
+            fetchChatContent: vi.fn().mockResolvedValue(fullChat()),
+        }
+
+        const hydration = ensureChatHydrated(chats, 0, 'character-1')
+        for (let i = 0; i < 6 && !frameCallback; i++) await Promise.resolve()
+        expect(frameCallback).toBeTypeOf('function')
+        chats.splice(0, 1)
+        frameCallback!(0)
+
+        await expect(hydration).resolves.toBeNull()
+        expect(chats).toHaveLength(0)
+    })
+
+    test('deduplicates requests for one array but not a replacement database array', async () => {
+        const fetchChatContent = vi.fn().mockResolvedValue(fullChat())
+        storageMock.realStorage = { fetchChatContent }
+        const firstDatabaseChats = [placeholder()]
+        const replacementDatabaseChats = [placeholder()]
+
+        const first = ensureChatHydrated(firstDatabaseChats, 0, 'character-1')
+        const duplicate = ensureChatHydrated(firstDatabaseChats, 0, 'character-1')
+        const replacement = ensureChatHydrated(replacementDatabaseChats, 0, 'character-1')
+
+        await Promise.all([first, duplicate, replacement])
+        expect(fetchChatContent).toHaveBeenCalledTimes(2)
+        expect(firstDatabaseChats[0]._placeholder).toBeUndefined()
+        expect(replacementDatabaseChats[0]._placeholder).toBeUndefined()
+        expect(hydrationInFlight.size).toBe(0)
+        expect(hydrationJustApplied.size).toBe(0)
     })
 })

--- a/src/ts/storage/chatStorage.ts
+++ b/src/ts/storage/chatStorage.ts
@@ -101,7 +101,53 @@ export const hydrationInFlight = new Set<string>()
 export const hydrationJustApplied = new Set<string>()
 
 /** Track in-flight hydration promises to avoid duplicate fetches */
-const hydrationPromises = new Map<string, Promise<Chat | null>>()
+const hydrationPromises = new Map<string, Map<Chat[], Promise<Chat | null>>>()
+const hydrationInFlightCounts = new Map<string, number>()
+const hydrationJustAppliedCounts = new Map<string, number>()
+
+function acquireHydrationState(set: Set<string>, counts: Map<string, number>, key: string): void {
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+    set.add(key)
+}
+
+function releaseHydrationState(set: Set<string>, counts: Map<string, number>, key: string): void {
+    const remaining = (counts.get(key) ?? 1) - 1
+    if (remaining > 0) {
+        counts.set(key, remaining)
+        return
+    }
+    counts.delete(key)
+    set.delete(key)
+}
+
+/**
+ * Yield briefly so the loading overlay can paint. Background tabs may suspend
+ * requestAnimationFrame indefinitely, so always keep a short timer fallback.
+ */
+function yieldForHydrationPaint(): Promise<void> {
+    return new Promise(resolve => {
+        let settled = false
+        const finish = () => {
+            if (settled) return
+            settled = true
+            clearTimeout(timeout)
+            resolve()
+        }
+        const timeout = setTimeout(finish, 50)
+        if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(finish)
+        }
+    })
+}
+
+function isValidHydratedChat(value: unknown, expectedChatId: string): value is Chat {
+    if (!value || typeof value !== 'object') return false
+    const chat = value as Partial<Chat> & { _stub?: boolean, _placeholder?: boolean }
+    return chat.id === expectedChatId
+        && Array.isArray(chat.message)
+        && chat._stub !== true
+        && chat._placeholder !== true
+}
 
 // ── Server fetch/save ───────────────────────────────────────────────────────
 
@@ -144,15 +190,20 @@ export async function ensureChatHydrated(
     const key = chatKey(chaId, chatId)
 
     // Deduplicate concurrent hydration for the same chat
-    const existing = hydrationPromises.get(key)
+    let promisesForKey = hydrationPromises.get(key)
+    const existing = promisesForKey?.get(chats)
     if (existing) return existing
 
     const promise = (async () => {
-        hydrationInFlight.add(key)
+        acquireHydrationState(hydrationInFlight, hydrationInFlightCounts, key)
         try {
             const full = await fetchChatFromServer(chaId, index, chatId)
             if (!full) {
                 console.error(`[chatStorage] hydrate failed: chat not found on server (${key})`)
+                return null
+            }
+            if (!isValidHydratedChat(full, chatId)) {
+                console.error(`[chatStorage] hydrate failed: invalid chat payload (${key})`)
                 return null
             }
 
@@ -166,26 +217,50 @@ export async function ensureChatHydrated(
             if (!currentSlot?._placeholder) {
                 return currentSlot
             }
+            if (currentSlot !== slot) {
+                console.warn(`[chatStorage] hydrate skipped: chat slot replaced before apply (${key})`)
+                return null
+            }
 
             // Yield one frame so loading overlay dismissal paints before heavy DOM work
-            await new Promise<void>(r => requestAnimationFrame(() => r()))
+            await yieldForHydrationPaint()
+
+            // The chat may be deleted, rerolled, or replaced while yielding.
+            const applyIndex = chats.findIndex(chat => chat?.id === chatId)
+            if (applyIndex === -1) {
+                console.warn(`[chatStorage] hydrate skipped: chat removed before apply (${key})`)
+                return null
+            }
+            if (chats[applyIndex] !== slot || !slot._placeholder) {
+                console.warn(`[chatStorage] hydrate skipped: chat slot replaced before apply (${key})`)
+                return null
+            }
 
             // Apply to memory — mark JustApplied to suppress the reactive write-back
-            hydrationJustApplied.add(key)
-            chats[currentIndex] = full
+            acquireHydrationState(hydrationJustApplied, hydrationJustAppliedCounts, key)
+            try {
+                chats[applyIndex] = full
 
-            // Wait one tick so Svelte reactivity settles before allowing dirty tracking
-            await tick()
-            hydrationJustApplied.delete(key)
+                // Wait one tick so Svelte reactivity settles before allowing dirty tracking
+                await tick()
+            } finally {
+                releaseHydrationState(hydrationJustApplied, hydrationJustAppliedCounts, key)
+            }
 
             return full
         } finally {
-            hydrationInFlight.delete(key)
-            hydrationPromises.delete(key)
+            releaseHydrationState(hydrationInFlight, hydrationInFlightCounts, key)
+            const activeForKey = hydrationPromises.get(key)
+            activeForKey?.delete(chats)
+            if (activeForKey?.size === 0) hydrationPromises.delete(key)
         }
     })()
 
-    hydrationPromises.set(key, promise)
+    if (!promisesForKey) {
+        promisesForKey = new Map()
+        hydrationPromises.set(key, promisesForKey)
+    }
+    promisesForKey.set(chats, promise)
     return promise
 }
 

--- a/src/ts/storage/conflictRebase.test.ts
+++ b/src/ts/storage/conflictRebase.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import { findTrackedDeletionConflict, mergeThreeWayValue, mergeTrackedChanges } from './conflictRebase'
+
+describe('conflict rebase', () => {
+    it('preserves local edits made while the original save was in flight', () => {
+        const base = {
+            username: 'old',
+            characters: [{
+                chaId: 'a',
+                name: 'old char',
+                chats: [{ id: 'c1', name: 'old chat', _stub: true }],
+            }],
+        }
+        const local = {
+            username: 'typed while waiting',
+            characters: [{
+                chaId: 'a',
+                name: 'locally edited',
+                chats: [{ id: 'c1', name: 'old chat', message: [{ role: 'user', data: 'new' }] }],
+            }],
+        }
+        const remote = {
+            username: 'old',
+            characters: [{
+                chaId: 'a',
+                name: 'old char',
+                chats: [{ id: 'c1', name: 'renamed remotely', _stub: true }],
+            }],
+        }
+
+        const merged = mergeThreeWayValue(base, local, remote)
+        expect(merged.username).toBe('typed while waiting')
+        expect(merged.characters[0].name).toBe('locally edited')
+        expect(merged.characters[0].chats[0].name).toBe('renamed remotely')
+        expect(merged.characters[0].chats[0].message).toEqual([{ role: 'user', data: 'new' }])
+        expect(merged.characters[0].chats[0]._stub).toBeUndefined()
+    })
+
+    it('does not revive a remotely deleted chat or lose a remote addition', () => {
+        const base = [{
+            chaId: 'a',
+            chats: [
+                { id: 'keep', name: 'Keep', _stub: true },
+                { id: 'deleted', name: 'Deleted', _stub: true },
+            ],
+        }]
+        const local = [{
+            chaId: 'a',
+            chats: [
+                { id: 'keep', name: 'Local rename', message: [] },
+                { id: 'deleted', name: 'Deleted', message: [{ role: 'user', data: 'stale' }] },
+                { id: 'local-new', name: 'Local new', message: [] },
+            ],
+        }]
+        const remote = [{
+            chaId: 'a',
+            chats: [
+                { id: 'keep', name: 'Keep', _stub: true },
+                { id: 'remote-new', name: 'Remote new', _stub: true },
+            ],
+        }]
+
+        const merged = mergeThreeWayValue(base, local, remote)
+        const ids = merged[0].chats.map((chat: any) => chat.id)
+        expect(ids).toEqual(['keep', 'local-new', 'remote-new'])
+        expect(merged[0].chats.find((chat: any) => chat.id === 'keep').name).toBe('Local rename')
+    })
+
+    it('keeps remote metadata when hydration is the only local shape change', () => {
+        const base = [{ chaId: 'a', chats: [{ id: 'c', name: 'Old', _stub: true }] }]
+        const local = [{ chaId: 'a', chats: [{ id: 'c', name: 'Old', _placeholder: true, message: [] }] }]
+        const remote = [{ chaId: 'a', chats: [{ id: 'c', name: 'Remote', folderId: 'f', _stub: true }] }]
+
+        const merged = mergeThreeWayValue(base, local, remote)
+        expect(merged[0].chats[0]).toMatchObject({
+            id: 'c',
+            name: 'Remote',
+            folderId: 'f',
+            _placeholder: true,
+            message: [],
+        })
+    })
+
+    it('combines pending tracker entries without duplicates', () => {
+        const primary = {
+            character: ['a'],
+            chat: [['a', 'c1']] as [string, string][],
+            root: false,
+            botPreset: true,
+            modules: false,
+            plugins: false,
+            pluginCustomStorage: false,
+        }
+        const pending = {
+            character: ['a', 'b'],
+            chat: [['a', 'c1'], ['b', 'c2']] as [string, string][],
+            root: true,
+            botPreset: false,
+            modules: true,
+            plugins: false,
+            pluginCustomStorage: true,
+        }
+
+        expect(mergeTrackedChanges(primary, pending)).toEqual({
+            character: ['a', 'b'],
+            chat: [['a', 'c1'], ['b', 'c2']],
+            root: true,
+            botPreset: true,
+            modules: true,
+            plugins: false,
+            pluginCustomStorage: true,
+        })
+    })
+
+    it('detects inactive chat metadata edits racing a remote deletion', () => {
+        const base = {
+            characters: [{ chaId: 'a', chats: [{ id: 'c', name: 'Old', _stub: true }] }],
+        }
+        const local = {
+            characters: [{ chaId: 'a', chats: [{ id: 'c', name: 'Renamed', _placeholder: true, message: [] }] }],
+        }
+        const remote = {
+            characters: [{ chaId: 'a', chats: [] }],
+        }
+        const changes = {
+            character: ['a'],
+            chat: [] as [string, string][],
+            root: false,
+            botPreset: false,
+            modules: false,
+            plugins: false,
+            pluginCustomStorage: false,
+        }
+        const toMetadata = (chat: any) => ({ id: chat.id, name: chat.name, _stub: true })
+
+        expect(findTrackedDeletionConflict(base, local, remote, changes, toMetadata)).toEqual({
+            scope: 'chat-metadata',
+            charId: 'a',
+            chatId: 'c',
+        })
+    })
+
+    it('does not treat placeholder hydration alone as a metadata edit', () => {
+        const base = {
+            characters: [{ chaId: 'a', chats: [{ id: 'c', name: 'Same', _stub: true }] }],
+        }
+        const local = {
+            characters: [{ chaId: 'a', chats: [{ id: 'c', name: 'Same', _placeholder: true, message: [] }] }],
+        }
+        const remote = { characters: [{ chaId: 'a', chats: [] }] }
+        const changes = {
+            character: ['a'],
+            chat: [] as [string, string][],
+            root: false,
+            botPreset: false,
+            modules: false,
+            plugins: false,
+            pluginCustomStorage: false,
+        }
+        const toMetadata = (chat: any) => ({ id: chat.id, name: chat.name, _stub: true })
+
+        expect(findTrackedDeletionConflict(base, local, remote, changes, toMetadata)).toBeNull()
+    })
+})

--- a/src/ts/storage/conflictRebase.ts
+++ b/src/ts/storage/conflictRebase.ts
@@ -1,0 +1,246 @@
+import type { toSaveType } from './risuSave'
+
+type JsonObject = Record<string, any>
+
+function isObject(value: unknown): value is JsonObject {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function cloneValue<T>(value: T): T {
+    if (value === undefined || value === null || typeof value !== 'object') {
+        return value
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => cloneValue(item)) as T
+    }
+
+    const cloned: JsonObject = {}
+    for (const key of Object.keys(value)) {
+        cloned[key] = cloneValue((value as JsonObject)[key])
+    }
+    return cloned as T
+}
+
+export function jsonValuesEqual(left: any, right: any): boolean {
+    if (Object.is(left, right)) return true
+    if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+        return left.every((item, index) => jsonValuesEqual(item, right[index]))
+    }
+    if (isObject(left) || isObject(right)) {
+        if (!isObject(left) || !isObject(right)) return false
+        const leftKeys = Object.keys(left)
+        const rightKeys = Object.keys(right)
+        if (leftKeys.length !== rightKeys.length) return false
+        return leftKeys.every((key) => Object.hasOwn(right, key) && jsonValuesEqual(left[key], right[key]))
+    }
+    return false
+}
+
+function stableArrayKey(arrays: any[][]): 'chaId' | 'id' | null {
+    for (const key of ['chaId', 'id'] as const) {
+        let sawItem = false
+        let valid = true
+        for (const array of arrays) {
+            const seen = new Set<string>()
+            for (const item of array) {
+                const id = isObject(item) ? item[key] : undefined
+                if (typeof id !== 'string' || id.length === 0 || seen.has(id)) {
+                    valid = false
+                    break
+                }
+                sawItem = true
+                seen.add(id)
+            }
+            if (!valid) break
+        }
+        if (valid && sawItem) return key
+    }
+    return null
+}
+
+function sameIds(left: string[], right: string[]): boolean {
+    return left.length === right.length && left.every((id, index) => id === right[index])
+}
+
+function mergeKeyedArray(base: any[], local: any[], remote: any[], key: 'chaId' | 'id'): any[] {
+    const baseById = new Map(base.map((item) => [item[key], item]))
+    const localById = new Map(local.map((item) => [item[key], item]))
+    const remoteById = new Map(remote.map((item) => [item[key], item]))
+    const mergedById = new Map<string, any>()
+
+    // Deletion wins over an edit. This is intentional for chats/characters:
+    // a stale tab must never revive an item deleted by another device.
+    for (const [id, baseItem] of baseById) {
+        if (!localById.has(id) || !remoteById.has(id)) continue
+        mergedById.set(id, mergeThreeWayValue(baseItem, localById.get(id), remoteById.get(id)))
+    }
+
+    for (const [id, localItem] of localById) {
+        if (baseById.has(id)) continue
+        if (remoteById.has(id)) {
+            mergedById.set(id, mergeThreeWayValue(undefined, localItem, remoteById.get(id)))
+        }
+        else {
+            mergedById.set(id, cloneValue(localItem))
+        }
+    }
+    for (const [id, remoteItem] of remoteById) {
+        if (!baseById.has(id) && !localById.has(id)) {
+            mergedById.set(id, cloneValue(remoteItem))
+        }
+    }
+
+    const baseIds = base.map((item) => item[key] as string)
+    const localIds = local.map((item) => item[key] as string)
+    const remoteIds = remote.map((item) => item[key] as string)
+    const localChangedStructure = !sameIds(baseIds, localIds)
+    const preferredOrder = localChangedStructure ? localIds : remoteIds
+    const secondaryOrder = localChangedStructure ? remoteIds : localIds
+    const result: any[] = []
+    const appended = new Set<string>()
+
+    for (const id of [...preferredOrder, ...secondaryOrder]) {
+        if (appended.has(id) || !mergedById.has(id)) continue
+        appended.add(id)
+        result.push(mergedById.get(id))
+    }
+    return result
+}
+
+/**
+ * Three-way merge a local runtime DB onto a freshly fetched server DB.
+ *
+ * The previous server baseline is the common ancestor. Unchanged local fields
+ * take the remote value, unchanged remote fields take the local value, and
+ * independent object-field edits are combined. Arrays with stable `chaId`/`id`
+ * keys are merged by identity so a stale chats array cannot overwrite remote
+ * additions, deletions or metadata changes wholesale.
+ */
+export function mergeThreeWayValue(base: any, local: any, remote: any): any {
+    if (jsonValuesEqual(local, base)) return cloneValue(remote)
+    if (jsonValuesEqual(remote, base)) return cloneValue(local)
+    if (jsonValuesEqual(local, remote)) return cloneValue(local)
+
+    if (Array.isArray(base) && Array.isArray(local) && Array.isArray(remote)) {
+        const key = stableArrayKey([base, local, remote])
+        if (key) return mergeKeyedArray(base, local, remote, key)
+        // There is no identity-safe way to merge concurrent edits to a
+        // positional array. Prefer the user's current local value.
+        return cloneValue(local)
+    }
+
+    if (isObject(base) && isObject(local) && isObject(remote)) {
+        const result: JsonObject = {}
+        const keys = new Set([...Object.keys(base), ...Object.keys(local), ...Object.keys(remote)])
+        for (const key of keys) {
+            const inBase = Object.hasOwn(base, key)
+            const inLocal = Object.hasOwn(local, key)
+            const inRemote = Object.hasOwn(remote, key)
+
+            if (inBase) {
+                // A deletion on either side wins, matching the identity-array
+                // rule and preventing stale state from resurrecting data.
+                if (!inLocal || !inRemote) continue
+                result[key] = mergeThreeWayValue(base[key], local[key], remote[key])
+            }
+            else if (inLocal && inRemote) {
+                result[key] = mergeThreeWayValue(undefined, local[key], remote[key])
+            }
+            else if (inLocal) {
+                result[key] = cloneValue(local[key])
+            }
+            else if (inRemote) {
+                result[key] = cloneValue(remote[key])
+            }
+        }
+        return result
+    }
+
+    // Both sides changed the same scalar or non-keyed value. Keep the local
+    // edit: it is the action this save attempt is trying to preserve.
+    return cloneValue(local)
+}
+
+export function mergeTrackedChanges(primary: toSaveType, pending: toSaveType): toSaveType {
+    const characters = [...new Set([...primary.character, ...pending.character].filter(Boolean))]
+    const seenChats = new Set<string>()
+    const chats = [...primary.chat, ...pending.chat].filter(([chaId, chatId]) => {
+        const key = `${chaId}|${chatId}`
+        if (!chaId || !chatId || seenChats.has(key)) return false
+        seenChats.add(key)
+        return true
+    })
+
+    return {
+        character: characters,
+        chat: chats,
+        root: primary.root || pending.root,
+        botPreset: primary.botPreset || pending.botPreset,
+        modules: primary.modules || pending.modules,
+        plugins: primary.plugins || pending.plugins,
+        pluginCustomStorage: primary.pluginCustomStorage || pending.pluginCustomStorage,
+    }
+}
+
+export type TrackedDeletionConflict = {
+    scope: 'character' | 'chat' | 'chat-metadata'
+    charId: string
+    chatId?: string
+}
+
+/**
+ * Detect deletion/edit races that must be surfaced instead of auto-merged.
+ * `chatMetadata` projects hydrated/placeholder chats to their server stub so
+ * hydration alone is not mistaken for a local metadata edit.
+ */
+export function findTrackedDeletionConflict(
+    base: any,
+    local: any,
+    remote: any,
+    changes: toSaveType,
+    chatMetadata: (chat: any) => any,
+): TrackedDeletionConflict | null {
+    const baseCharacters: any[] = Array.isArray(base?.characters) ? base.characters : []
+    const localCharacters: any[] = Array.isArray(local?.characters) ? local.characters : []
+    const remoteCharacters: any[] = Array.isArray(remote?.characters) ? remote.characters : []
+
+    const characterById = (characters: any[], charId: string) => (
+        characters.find((character) => character?.chaId === charId)
+    )
+
+    for (const charId of changes.character) {
+        const baseChar = characterById(baseCharacters, charId)
+        const localChar = characterById(localCharacters, charId)
+        const remoteChar = characterById(remoteCharacters, charId)
+        if (baseChar && localChar && !remoteChar) {
+            return { scope: 'character', charId }
+        }
+        if (!baseChar || !localChar || !remoteChar) continue
+
+        const remoteChatIds = new Set(
+            (remoteChar.chats ?? []).map((chat: any) => chat?.id).filter(Boolean),
+        )
+        for (const baseChat of baseChar.chats ?? []) {
+            if (!baseChat?.id || remoteChatIds.has(baseChat.id)) continue
+            const localChat = localChar.chats?.find((chat: any) => chat?.id === baseChat.id)
+            if (localChat && !jsonValuesEqual(chatMetadata(localChat), chatMetadata(baseChat))) {
+                return { scope: 'chat-metadata', charId, chatId: baseChat.id }
+            }
+        }
+    }
+
+    for (const [charId, chatId] of changes.chat) {
+        const baseChat = characterById(baseCharacters, charId)?.chats
+            ?.find((chat: any) => chat?.id === chatId)
+        const localChat = characterById(localCharacters, charId)?.chats
+            ?.find((chat: any) => chat?.id === chatId)
+        const remoteChat = characterById(remoteCharacters, charId)?.chats
+            ?.find((chat: any) => chat?.id === chatId)
+        if (baseChat && localChat && !remoteChat) {
+            return { scope: 'chat', charId, chatId }
+        }
+    }
+
+    return null
+}

--- a/src/ts/storage/nodeStorage.chatDelta.test.ts
+++ b/src/ts/storage/nodeStorage.chatDelta.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('src/lang', () => ({ language: {} }))
+vi.mock('../alert', () => ({
+    alertInput: vi.fn(),
+    waitAlert: vi.fn(),
+    notifyError: vi.fn(),
+}))
+vi.mock('./database.svelte', () => ({
+    appVer: 'test-app',
+    nodeOnlyVer: 'test-node',
+    normalizeChat: (chat: any) => chat,
+}))
+vi.mock('./risuSave', () => ({
+    encodeRisuSaveLegacy: (value: unknown) =>
+        new TextEncoder().encode(JSON.stringify(value)),
+    decodeRisuSave: async (bytes: Uint8Array) =>
+        JSON.parse(new TextDecoder().decode(bytes)),
+}))
+
+const { ChatConflictError, NodeStorage } = await import('./nodeStorage')
+
+const fakeStartupCache = {
+    probe: vi.fn(async () => null),
+    resolveNotModified: vi.fn(async () => null),
+    storeAuthoritative: vi.fn(async () => ({ rawStored: true, decodedStored: true })),
+    recordPatch: vi.fn(async () => 'recorded'),
+    invalidate: vi.fn(async () => undefined),
+}
+
+function chat(messages: Array<{ role: string, data: string }>) {
+    return { id: 'chat-1', name: 'Chat', message: messages }
+}
+
+function makeStorage(responses: Array<Response | Error>) {
+    const storage = new NodeStorage(fakeStartupCache as any)
+    const authFetch = vi.fn(async (
+        _input: RequestInfo | URL,
+        _init: RequestInit = {},
+    ): Promise<Response> => {
+        const response = responses.shift()
+        if (!response) throw new Error('Unexpected request')
+        if (response instanceof Error) throw response
+        return response
+    })
+    ;(storage as any).authFetch = authFetch
+    return { storage, authFetch }
+}
+
+function seedRevision(storage: InstanceType<typeof NodeStorage>, snapshot: any | null) {
+    ;(storage as any).chatSyncStates.set('char-1|chat-1', {
+        revision: 'revision-1',
+        snapshot,
+        encodedBytes: snapshot ? JSON.stringify(snapshot).length : 0,
+    })
+}
+
+function serverChatResponse(value: unknown, revision: string, status = 200) {
+    return new Response(JSON.stringify(value), {
+        status,
+        headers: {
+            'content-type': 'application/octet-stream',
+            'x-chat-revision': revision,
+        },
+    })
+}
+
+describe('NodeStorage chat revision safety', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    test('a delta conflict never falls through to a full overwrite', async () => {
+        const original = chat([{ role: 'char', data: 'x'.repeat(12_000) }])
+        const changed = chat([
+            ...original.message,
+            { role: 'user', data: 'small append' },
+        ])
+        const remote = chat([
+            ...original.message,
+            { role: 'user', data: 'different remote append' },
+        ])
+        const conflict = new Response(JSON.stringify({
+            error: 'Chat revision mismatch',
+            currentRevision: 'revision-2',
+        }), {
+            status: 409,
+            headers: {
+                'content-type': 'application/json',
+                'x-chat-revision': 'revision-2',
+            },
+        })
+        const { storage, authFetch } = makeStorage([
+            conflict,
+            serverChatResponse(remote, 'revision-2'),
+        ])
+        seedRevision(storage, original)
+
+        await expect(storage.saveChatContent('char-1', 0, 'chat-1', changed))
+            .rejects.toBeInstanceOf(ChatConflictError)
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        expect(String(authFetch.mock.calls[0]![0])).toContain('/patch')
+        expect(String(authFetch.mock.calls[1]![0])).not.toContain('/patch')
+    })
+
+    test('a revision-only state uses CAS for a full save', async () => {
+        const success = new Response(JSON.stringify({ revision: 'revision-2' }), {
+            status: 200,
+            headers: {
+                'content-type': 'application/json',
+                'x-chat-revision': 'revision-2',
+            },
+        })
+        const { storage, authFetch } = makeStorage([success])
+        seedRevision(storage, null)
+
+        await storage.saveChatContent(
+            'char-1',
+            0,
+            'chat-1',
+            chat([{ role: 'user', data: 'full save' }]),
+        )
+
+        const [, request] = authFetch.mock.calls[0]!
+        expect((request.headers as Record<string, string>)['x-chat-base-revision'])
+            .toBe('revision-1')
+        expect(String(authFetch.mock.calls[0]![0])).not.toContain('/patch')
+    })
+
+    test('an unsupported delta endpoint falls back once but keeps the base revision', async () => {
+        const original = chat([{ role: 'char', data: 'x'.repeat(12_000) }])
+        const changed = chat([
+            ...original.message,
+            { role: 'user', data: 'small append' },
+        ])
+        const unsupported = new Response('', { status: 405 })
+        const success = new Response(JSON.stringify({ revision: 'revision-2' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        })
+        const { storage, authFetch } = makeStorage([unsupported, success])
+        seedRevision(storage, original)
+
+        await storage.saveChatContent('char-1', 0, 'chat-1', changed)
+
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        expect((authFetch.mock.calls[1]![1].headers as Record<string, string>)['x-chat-base-revision'])
+            .toBe('revision-1')
+    })
+
+    test('recovers a lost delta acknowledgement when a fresh GET matches the desired snapshot', async () => {
+        const original = chat([{ role: 'char', data: 'x'.repeat(12_000) }])
+        const changed = chat([
+            ...original.message,
+            { role: 'user', data: 'small append' },
+        ])
+        const { storage, authFetch } = makeStorage([
+            new TypeError('connection reset after commit'),
+            serverChatResponse(changed, 'revision-2'),
+        ])
+        seedRevision(storage, original)
+
+        await expect(storage.saveChatContent('char-1', 0, 'chat-1', changed))
+            .resolves.toBeUndefined()
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        expect(String(authFetch.mock.calls[0]![0])).toContain('/patch')
+        expect(String(authFetch.mock.calls[1]![0])).not.toContain('/patch')
+        expect((storage as any).chatSyncStates.get('char-1|chat-1').revision)
+            .toBe('revision-2')
+    })
+
+    test('treats a delta 409 as a lost ACK when the authoritative chat already matches', async () => {
+        const original = chat([{ role: 'char', data: 'x'.repeat(12_000) }])
+        const changed = chat([
+            ...original.message,
+            { role: 'user', data: 'small append' },
+        ])
+        const conflict = new Response(JSON.stringify({
+            error: 'Chat revision mismatch',
+            currentRevision: 'revision-2',
+        }), {
+            status: 409,
+            headers: { 'content-type': 'application/json' },
+        })
+        const { storage, authFetch } = makeStorage([
+            conflict,
+            serverChatResponse(changed, 'revision-2'),
+        ])
+        seedRevision(storage, original)
+
+        await expect(storage.saveChatContent('char-1', 0, 'chat-1', changed))
+            .resolves.toBeUndefined()
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        expect((storage as any).chatSyncStates.get('char-1|chat-1').revision)
+            .toBe('revision-2')
+    })
+
+    test('keeps a real delta conflict when the authoritative chat differs', async () => {
+        const original = chat([{ role: 'char', data: 'x'.repeat(12_000) }])
+        const changed = chat([
+            ...original.message,
+            { role: 'user', data: 'local append' },
+        ])
+        const remote = chat([
+            ...original.message,
+            { role: 'user', data: 'remote append' },
+        ])
+        const conflict = new Response(JSON.stringify({
+            error: 'Chat revision mismatch',
+            currentRevision: 'revision-2',
+        }), {
+            status: 409,
+            headers: { 'content-type': 'application/json' },
+        })
+        const { storage, authFetch } = makeStorage([
+            conflict,
+            serverChatResponse(remote, 'revision-2'),
+        ])
+        seedRevision(storage, original)
+
+        await expect(storage.saveChatContent('char-1', 0, 'chat-1', changed))
+            .rejects.toBeInstanceOf(ChatConflictError)
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        expect((storage as any).chatSyncStates.get('char-1|chat-1').revision)
+            .toBe('revision-1')
+    })
+
+    test('preflights an unknown existing chat and saves it with a seeded revision', async () => {
+        const original = chat([{ role: 'char', data: 'server copy' }])
+        const changed = chat([{ role: 'char', data: 'local edit' }])
+        const success = new Response(JSON.stringify({ revision: 'revision-2' }), {
+            status: 200,
+            headers: {
+                'content-type': 'application/json',
+                'x-chat-revision': 'revision-2',
+            },
+        })
+        const { storage, authFetch } = makeStorage([
+            serverChatResponse(original, 'revision-1'),
+            success,
+        ])
+
+        await storage.saveChatContent('char-1', 0, 'chat-1', changed)
+
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        const [, saveRequest] = authFetch.mock.calls[1]!
+        expect((saveRequest.headers as Record<string, string>)['x-chat-base-revision'])
+            .toBe('revision-1')
+        expect((saveRequest.headers as Record<string, string>)['if-none-match'])
+            .toBeUndefined()
+    })
+
+    test('uses an explicit create-only precondition after an authoritative 404', async () => {
+        const created = chat([{ role: 'user', data: 'brand new chat' }])
+        const success = new Response(JSON.stringify({ revision: 'revision-1' }), {
+            status: 200,
+            headers: {
+                'content-type': 'application/json',
+                'x-chat-revision': 'revision-1',
+            },
+        })
+        const { storage, authFetch } = makeStorage([
+            new Response('', { status: 404 }),
+            success,
+        ])
+
+        await storage.saveChatContent('char-1', 0, 'chat-1', created)
+
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        const [, saveRequest] = authFetch.mock.calls[1]!
+        expect((saveRequest.headers as Record<string, string>)['if-none-match'])
+            .toBe('*')
+        expect((saveRequest.headers as Record<string, string>)['x-chat-base-revision'])
+            .toBeUndefined()
+    })
+
+    test('recovers a lost full-save acknowledgement by verifying the server snapshot', async () => {
+        const changed = chat([{ role: 'user', data: 'full save' }])
+        const { storage, authFetch } = makeStorage([
+            new TypeError('connection reset after commit'),
+            serverChatResponse(changed, 'revision-2'),
+        ])
+        seedRevision(storage, null)
+
+        await expect(storage.saveChatContent('char-1', 0, 'chat-1', changed))
+            .resolves.toBeUndefined()
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        expect((storage as any).chatSyncStates.get('char-1|chat-1').revision)
+            .toBe('revision-2')
+    })
+})
+
+describe('NodeStorage startup database revalidation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        fakeStartupCache.probe.mockResolvedValue(null)
+        fakeStartupCache.resolveNotModified.mockResolvedValue(null)
+    })
+
+    test('uses a decoded object only after the server confirms its ETag', async () => {
+        const cachedDatabase = { characters: [], username: 'cached' }
+        fakeStartupCache.probe.mockResolvedValue({ etag: 'db-etag-1', source: 'decoded' } as any)
+        fakeStartupCache.resolveNotModified.mockResolvedValue({
+            kind: 'decoded',
+            etag: 'db-etag-1',
+            database: cachedDatabase,
+        } as any)
+        const { storage, authFetch } = makeStorage([
+            new Response(null, { status: 304 }),
+        ])
+
+        const loaded = await storage.loadDatabaseForStartup()
+
+        expect(loaded).toMatchObject({
+            decoded: cachedDatabase,
+            bytes: null,
+            etag: 'db-etag-1',
+            fromCache: true,
+        })
+        const request = authFetch.mock.calls[0]![1]
+        expect((request.headers as Record<string, string>)['if-none-match'])
+            .toBe('db-etag-1')
+    })
+
+    test('retries unconditionally when a 304 has no matching cached body', async () => {
+        fakeStartupCache.probe.mockResolvedValue({ etag: 'db-etag-1', source: 'raw' } as any)
+        fakeStartupCache.resolveNotModified.mockResolvedValue(null)
+        const authoritative = new TextEncoder().encode('{"characters":[]}')
+        const { storage, authFetch } = makeStorage([
+            new Response(null, { status: 304 }),
+            new Response(authoritative, {
+                status: 200,
+                headers: { 'x-db-etag': 'db-etag-2' },
+            }),
+        ])
+
+        const loaded = await storage.loadDatabaseForStartup()
+
+        expect(authFetch).toHaveBeenCalledTimes(2)
+        expect(fakeStartupCache.invalidate).toHaveBeenCalledTimes(1)
+        expect(loaded.fromCache).toBe(false)
+        expect(loaded.etag).toBe('db-etag-2')
+        expect(loaded.bytes).toEqual(authoritative)
+        const retryRequest = authFetch.mock.calls[1]![1]
+        expect((retryRequest.headers as Record<string, string>)['if-none-match'])
+            .toBeUndefined()
+    })
+})

--- a/src/ts/storage/nodeStorage.ts
+++ b/src/ts/storage/nodeStorage.ts
@@ -8,7 +8,20 @@
 import { language } from "src/lang"
 import { alertInput, waitAlert, notifyError } from "../alert"
 import { decodeRisuSave, encodeRisuSaveLegacy } from "./risuSave"
-import { normalizeChat } from "./database.svelte"
+import { appVer, nodeOnlyVer, normalizeChat } from "./database.svelte"
+import { StartupDatabaseCache } from "./startupDatabaseCache"
+
+const DATABASE_KEY = 'database/database.bin'
+// Bump this when decoding the same bytes can produce a different runtime shape.
+const STARTUP_DATABASE_SCHEMA_EPOCH = 1
+
+function responseDatabaseEtag(response: Response): string | null {
+    const legacy = response.headers.get('x-db-etag')
+    if (legacy) return legacy
+    const standard = response.headers.get('etag')
+    if (!standard) return null
+    return standard.replace(/^W\//, '').replace(/^"|"$/g, '') || null
+}
 
 // Custom error class for database conflict detection
 export class ConflictError extends Error {
@@ -35,10 +48,68 @@ export interface PatchItemResult {
     persistWarning?: PersistWarning
     /** Set when the server's chat-internal-field guard rejected the patch. */
     chatGuardRejected?: boolean
+    /** A stale database hash/ETag must be rebased, never full-written. */
+    conflict?: boolean
+    /** The proposed database shape is invalid and must not be retried as full. */
+    validationRejected?: boolean
+    error?: string
+}
+
+export interface StartupDatabaseLoadResult {
+    bytes: Uint8Array | null
+    decoded: any | null
+    etag: string | null
+    fromCache: boolean
+}
+
+export class ChatConflictError extends Error {
+    currentRevision: string | null
+
+    constructor(message: string, currentRevision: string | null = null) {
+        super(message)
+        this.name = 'ChatConflictError'
+        this.currentRevision = currentRevision
+    }
+}
+
+interface ChatSyncState {
+    revision: string
+    snapshot: any | null
+    encodedBytes: number
+}
+
+interface ServerChatSnapshot {
+    revision: string
+    chat: any
+    encodedBytes: number
+}
+
+function isPlainJsonValue(value: unknown, seen = new Set<object>()): boolean {
+    if (value === null) return true
+    if (typeof value === 'string' || typeof value === 'boolean') return true
+    if (typeof value === 'number') return Number.isFinite(value)
+    if (typeof value !== 'object') return false
+    if (seen.has(value)) return false
+    seen.add(value)
+    try {
+        if (Array.isArray(value)) {
+            return value.every((entry) => isPlainJsonValue(entry, seen))
+        }
+        const prototype = Object.getPrototypeOf(value)
+        if (prototype !== Object.prototype && prototype !== null) return false
+        return Object.values(value as Record<string, unknown>)
+            .every((entry) => isPlainJsonValue(entry, seen))
+    }
+    finally {
+        seen.delete(value)
+    }
 }
 
 export class NodeStorage{
     private static readonly BULK_WRITE_CLIENT_BATCH = 20
+    private static readonly MAX_CHAT_SYNC_STATES = 4
+    private static readonly MAX_CHAT_SYNC_STATE_BYTES = 16 * 1024 * 1024
+    private static readonly MAX_SINGLE_CHAT_SYNC_BYTES = 8 * 1024 * 1024
 
     // Unique per page load — used for cross-device single-writer lock
     private static sessionId: string =
@@ -50,6 +121,19 @@ export class NodeStorage{
     private static sessionInitialized = false
     private static sessionPending: Promise<void> | null = null
     private refreshPending: Promise<string> | null = null
+    private readonly startupDatabaseCache: StartupDatabaseCache
+    private readonly chatSyncStates = new Map<string, ChatSyncState>()
+    private readonly chatSaveTails = new Map<string, Promise<void>>()
+    private chatSyncStateBytes = 0
+    private chatSyncSnapshotCount = 0
+    private chatDeltaSupported: boolean | null = null
+
+    constructor(startupDatabaseCache?: StartupDatabaseCache) {
+        this.startupDatabaseCache = startupDatabaseCache ?? new StartupDatabaseCache({
+            appVersion: `${appVer}:${nodeOnlyVer}`,
+            schemaEpoch: STARTUP_DATABASE_SCHEMA_EPOCH,
+        })
+    }
 
     async createAuth(){
         const now = Date.now()
@@ -184,6 +268,120 @@ export class NodeStorage{
         return response
     }
 
+    private databaseReadHeaders(): Record<string, string> {
+        return {
+            'file-path': Buffer.from(DATABASE_KEY, 'utf-8').toString('hex'),
+        }
+    }
+
+    private async readDatabaseUnconditionally(): Promise<StartupDatabaseLoadResult> {
+        const response = await this.authFetch('/api/read', {
+            method: 'GET',
+            headers: this.databaseReadHeaders(),
+        })
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error(`getItem Error (${response.status})`)
+        }
+
+        const etag = responseDatabaseEtag(response)
+        if (etag) this._lastDbEtag = etag
+        const bytes = new Uint8Array(await response.arrayBuffer())
+        return {
+            bytes: bytes.byteLength > 0 ? bytes : null,
+            decoded: null,
+            etag,
+            fromCache: false,
+        }
+    }
+
+    /**
+     * Revalidate the startup cache before reading it. A cached object is never
+     * trusted on its own: the authenticated server must first answer 304 for
+     * the exact cached ETag. Missing/corrupt cache data falls back to a fresh
+     * unconditional response in the same call.
+     */
+    async loadDatabaseForStartup(): Promise<StartupDatabaseLoadResult> {
+        const probe = await this.startupDatabaseCache.probe()
+        if (!probe) return this.readDatabaseUnconditionally()
+
+        const headers = this.databaseReadHeaders()
+        headers['if-none-match'] = probe.etag
+        const response = await this.authFetch('/api/read', { method: 'GET', headers })
+
+        if (response.status === 304) {
+            const hit = await this.startupDatabaseCache.resolveNotModified(probe.etag, {
+                validateDecoded: (database) => !!database
+                    && typeof database === 'object'
+                    && !Array.isArray(database),
+            })
+            if (hit?.kind === 'decoded') {
+                this._lastDbEtag = hit.etag
+                return {
+                    bytes: null,
+                    decoded: hit.database,
+                    etag: hit.etag,
+                    fromCache: true,
+                }
+            }
+            if (hit?.kind === 'raw') {
+                this._lastDbEtag = hit.etag
+                return {
+                    bytes: hit.bytes,
+                    decoded: null,
+                    etag: hit.etag,
+                    fromCache: true,
+                }
+            }
+
+            // The server confirmed the metadata but the matching body was
+            // evicted/corrupt. Retry without the validator instead of treating
+            // an empty 304 response as a new database.
+            await this.startupDatabaseCache.invalidate()
+            return this.readDatabaseUnconditionally()
+        }
+
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error(`getItem Error (${response.status})`)
+        }
+        const etag = responseDatabaseEtag(response)
+        if (etag) this._lastDbEtag = etag
+        const bytes = new Uint8Array(await response.arrayBuffer())
+        return {
+            bytes: bytes.byteLength > 0 ? bytes : null,
+            decoded: null,
+            etag,
+            fromCache: false,
+        }
+    }
+
+    /** Schedule large CacheStorage/IndexedDB writes outside the boot path. */
+    scheduleStartupDatabaseCache(bytes: Uint8Array, decoded: any, etag = this._lastDbEtag): void {
+        if (!etag || !bytes?.byteLength || !decoded) return
+        const write = () => {
+            void this.startupDatabaseCache.storeAuthoritative({ etag, bytes, decoded })
+                .catch(() => undefined)
+        }
+        if (typeof requestIdleCallback === 'function') {
+            requestIdleCallback(write, { timeout: 2_000 })
+        }
+        else {
+            setTimeout(write, 0)
+        }
+    }
+
+    async invalidateStartupDatabaseCache(): Promise<void> {
+        await this.startupDatabaseCache.invalidate()
+    }
+
+    private async invalidateAfterDatabaseReplacement(): Promise<void> {
+        this._lastDbEtag = null
+        this.chatSyncStates.clear()
+        this.chatSyncStateBytes = 0
+        this.chatSyncSnapshotCount = 0
+        this.chatDeltaSupported = null
+        await this.startupDatabaseCache.invalidate()
+    }
+
     async setItem(key:string, value:Uint8Array, etag?:string) {
         const headers: Record<string, string> = {
             'content-type': 'application/octet-stream',
@@ -202,15 +400,19 @@ export class NodeStorage{
             throw new ConflictError(data.error, data.currentEtag)
         }
         if(da.status < 200 || da.status >= 300){
-            throw "setItem Error"
+            const data = await da.clone().json().catch(() => ({}))
+            throw new Error(data?.detail || data?.error || `setItem Error (${da.status})`)
         }
         const data = await da.json()
         if(data.error){
             throw data.error
         }
         const nextEtag = data.etag as string | undefined
-        if (key === 'database/database.bin' && nextEtag) {
-            this._lastDbEtag = nextEtag
+        if (key === DATABASE_KEY) {
+            if (nextEtag) this._lastDbEtag = nextEtag
+            // The server may canonicalize/split the submitted bytes before
+            // hashing them, so never label the outgoing body with its ETag.
+            void this.startupDatabaseCache.invalidate().catch(() => undefined)
         }
     }
     async getItem(key:string):Promise<Buffer> {
@@ -224,7 +426,7 @@ export class NodeStorage{
         }
 
         // Capture ETag for database.bin
-        const etag = da.headers.get('x-db-etag')
+        const etag = responseDatabaseEtag(da)
         if (etag) {
             this._lastDbEtag = etag
         }
@@ -235,6 +437,13 @@ export class NodeStorage{
         }
 
         return data
+    }
+
+    async getItemFresh(key: string): Promise<Buffer> {
+        if (key === DATABASE_KEY) {
+            await this.startupDatabaseCache.invalidate()
+        }
+        return this.getItem(key)
     }
     async keys(prefix: string = ''):Promise<string[]>{
         const headers: Record<string, string> = {
@@ -268,6 +477,10 @@ export class NodeStorage{
         const data = await da.json()
         if(data.error){
             throw data.error
+        }
+        if (key === DATABASE_KEY) {
+            this._lastDbEtag = null
+            void this.startupDatabaseCache.invalidate().catch(() => undefined)
         }
     }
 
@@ -324,6 +537,7 @@ export class NodeStorage{
     }
 
     async patchItem(key: string, patchData: { patch: any[], expectedHash: string }): Promise<PatchItemResult> {
+        const previousEtag = key === DATABASE_KEY ? this._lastDbEtag : null
         const da = await this.authFetch('/api/patch', {
             method: "POST",
             body: JSON.stringify(patchData),
@@ -336,16 +550,21 @@ export class NodeStorage{
         if (da.status === 409) {
             const data = await da.json()
             const currentEtag = data.currentEtag as string | undefined
-            if (key === 'database/database.bin' && currentEtag) {
-                this._lastDbEtag = currentEtag
-            }
             // Server signals chat-guard rejection via explicit fields. The
             // error string fallback is kept for forward-compat with deployed
             // servers that haven't shipped the explicit fields yet.
             const rejectedByChatGuard = data.chatGuardRejected === true
                 || data.code === 'CHAT_GUARD_REJECTED'
                 || (typeof data.error === 'string' && data.error.includes('chat-internal field ops'))
-            return { success: false, etag: currentEtag, chatGuardRejected: rejectedByChatGuard }
+            const rejectedByValidation = data.code === 'DB_INVARIANT_REJECTED'
+            return {
+                success: false,
+                etag: currentEtag,
+                chatGuardRejected: rejectedByChatGuard,
+                validationRejected: rejectedByValidation,
+                conflict: !rejectedByChatGuard && !rejectedByValidation,
+                error: typeof data.detail === 'string' ? data.detail : data.error,
+            }
         }
         if (da.status < 200 || da.status >= 300) {
             return { success: false }
@@ -355,8 +574,15 @@ export class NodeStorage{
             return { success: false }
         }
         const nextEtag = data.etag as string | undefined
-        if (key === 'database/database.bin' && nextEtag) {
+        if (key === DATABASE_KEY && nextEtag) {
             this._lastDbEtag = nextEtag
+            if (previousEtag) {
+                void this.startupDatabaseCache.recordPatch({
+                    previousEtag,
+                    nextEtag,
+                    patch: patchData.patch,
+                }).catch(() => undefined)
+            }
         }
         const persistWarning = data.persistWarning as PersistWarning | undefined
         return { success: true, etag: nextEtag, persistWarning }
@@ -446,7 +672,7 @@ export class NodeStorage{
         await this.prepareImport(file.size)
         const authHeader = await this.createAuth()
 
-        return await new Promise((resolve, reject) => {
+        const result = await new Promise<{ok: boolean, assetsRestored: number, coldStorageFailed?: number}>((resolve, reject) => {
             const xhr = new XMLHttpRequest()
             xhr.open('POST', '/api/backup/import')
             xhr.setRequestHeader('content-type', 'application/x-risu-backup')
@@ -513,6 +739,8 @@ export class NodeStorage{
 
             xhr.send(file)
         })
+        await this.invalidateAfterDatabaseReplacement()
+        return result
     }
 
     // ── Server-side backup ─────────────────────────────────────────────────────
@@ -608,6 +836,7 @@ export class NodeStorage{
             }
         }
         if (!result) throw new Error('Server backup restore: no result received')
+        await this.invalidateAfterDatabaseReplacement()
         return result
     }
 
@@ -628,27 +857,403 @@ export class NodeStorage{
 
     // ── Chat content (runtime lazy load) ────────────────────────────────────
 
-    async fetchChatContent(chaId: string, chatIndex: number, chatId: string): Promise<any | null> {
-        const da = await this.authFetch(`/api/chat-content/${encodeURIComponent(chaId)}/${chatIndex}`, {
-            headers: { 'x-chat-id': chatId },
+    private chatSyncKey(chaId: string, chatId: string): string {
+        return `${chaId}|${chatId}`
+    }
+
+    private forgetChatSyncState(key: string): void {
+        const previous = this.chatSyncStates.get(key)
+        if (previous?.snapshot) {
+            this.chatSyncStateBytes -= previous.encodedBytes
+            this.chatSyncSnapshotCount -= 1
+        }
+        this.chatSyncStates.delete(key)
+    }
+
+    private rememberChatSyncState(
+        key: string,
+        revision: string,
+        chat: any,
+        encodedBytes: number,
+    ): void {
+        this.forgetChatSyncState(key)
+
+        let snapshot: any | null = null
+        let retainedBytes = 0
+        if (
+            isPlainJsonValue(chat)
+            && encodedBytes > 0
+            && encodedBytes <= NodeStorage.MAX_SINGLE_CHAT_SYNC_BYTES
+        ) {
+            try {
+                snapshot = structuredClone(chat)
+                retainedBytes = encodedBytes
+            } catch {
+                snapshot = null
+            }
+        }
+
+        this.chatSyncStates.set(key, {
+            revision,
+            snapshot,
+            encodedBytes: retainedBytes,
         })
-        if (da.status === 404) return null
-        if (da.status < 200 || da.status >= 300) throw new Error(`fetchChatContent error: ${da.status}`)
-        const buffer = new Uint8Array(await da.arrayBuffer())
-        return normalizeChat(await decodeRisuSave(buffer))
+        if (snapshot) {
+            this.chatSyncStateBytes += retainedBytes
+            this.chatSyncSnapshotCount += 1
+        }
+
+        // Keep revisions for CAS safety, but discard old deep snapshots first.
+        // This bounds the mobile-memory multiplier without allowing an evicted
+        // existing chat to fall back to an unconditional full overwrite.
+        while (
+            this.chatSyncSnapshotCount > NodeStorage.MAX_CHAT_SYNC_STATES
+            || this.chatSyncStateBytes > NodeStorage.MAX_CHAT_SYNC_STATE_BYTES
+        ) {
+            const oldest = [...this.chatSyncStates.entries()]
+                .find(([, state]) => state.snapshot !== null)
+            if (!oldest) break
+            const [oldestKey, state] = oldest
+            this.chatSyncStateBytes -= state.encodedBytes
+            this.chatSyncSnapshotCount -= 1
+            this.chatSyncStates.set(oldestKey, {
+                ...state,
+                snapshot: null,
+                encodedBytes: 0,
+            })
+        }
+    }
+
+    private chatRevisionFromResponse(response: Response, body?: any): string | null {
+        return response.headers.get('x-chat-revision')
+            ?? response.headers.get('etag')?.replace(/^W\//, '').replace(/^"|"$/g, '')
+            ?? (typeof body?.revision === 'string' ? body.revision : null)
+            ?? (typeof body?.currentRevision === 'string' ? body.currentRevision : null)
+    }
+
+    /**
+     * Read a chat without changing the local sync baseline. Callers decide
+     * whether the returned snapshot is safe to adopt. This distinction is
+     * important after a lost save acknowledgement: adopting a different
+     * server snapshot would make the next retry overwrite a real conflict.
+     */
+    private async readServerChatSnapshot(
+        chaId: string,
+        chatIndex: number,
+        chatId: string,
+    ): Promise<ServerChatSnapshot | null> {
+        const response = await this.authFetch(
+            `/api/chat-content/${encodeURIComponent(chaId)}/${chatIndex}`,
+            {
+                cache: 'no-store',
+                headers: { 'x-chat-id': chatId },
+            },
+        )
+        if (response.status === 404) return null
+        if (response.status === 409 || response.status === 412) {
+            const body = await response.clone().json().catch(() => ({}))
+            throw new ChatConflictError(
+                body?.error || 'Chat changed on the server',
+                this.chatRevisionFromResponse(response, body),
+            )
+        }
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error(`fetchChatContent error: ${response.status}`)
+        }
+
+        const buffer = new Uint8Array(await response.arrayBuffer())
+        const chat = normalizeChat(await decodeRisuSave(buffer))
+        if (chat?.id !== chatId || !Array.isArray(chat?.message)) {
+            throw new Error('fetchChatContent returned an invalid or mismatched chat')
+        }
+        const revision = this.chatRevisionFromResponse(response)
+        if (!revision) {
+            throw new Error('fetchChatContent returned no chat revision')
+        }
+        return {
+            revision,
+            chat,
+            encodedBytes: buffer.byteLength,
+        }
+    }
+
+    private async confirmCurrentSnapshotOnServer(
+        chaId: string,
+        chatIndex: number,
+        chatId: string,
+        currentSnapshot: any,
+        encodedBytes: number,
+    ): Promise<{ confirmed: boolean, currentRevision: string | null }> {
+        try {
+            const serverSnapshot = await this.readServerChatSnapshot(chaId, chatIndex, chatId)
+            if (!serverSnapshot || !isPlainJsonValue(serverSnapshot.chat)) {
+                return { confirmed: false, currentRevision: null }
+            }
+            const { compare } = await import('fast-json-patch')
+            if (compare(serverSnapshot.chat, currentSnapshot).length !== 0) {
+                return {
+                    confirmed: false,
+                    currentRevision: serverSnapshot.revision,
+                }
+            }
+
+            this.rememberChatSyncState(
+                this.chatSyncKey(chaId, chatId),
+                serverSnapshot.revision,
+                currentSnapshot,
+                encodedBytes,
+            )
+            this.chatDeltaSupported = true
+            return {
+                confirmed: true,
+                currentRevision: serverSnapshot.revision,
+            }
+        }
+        catch (error) {
+            return {
+                confirmed: false,
+                currentRevision: error instanceof ChatConflictError
+                    ? error.currentRevision
+                    : null,
+            }
+        }
+    }
+
+    async fetchChatContent(chaId: string, chatIndex: number, chatId: string): Promise<any | null> {
+        const serverSnapshot = await this.readServerChatSnapshot(chaId, chatIndex, chatId)
+        if (!serverSnapshot) return null
+        this.rememberChatSyncState(
+            this.chatSyncKey(chaId, chatId),
+            serverSnapshot.revision,
+            serverSnapshot.chat,
+            serverSnapshot.encodedBytes,
+        )
+        this.chatDeltaSupported = true
+        return serverSnapshot.chat
     }
 
     async saveChatContent(chaId: string, chatIndex: number, chatId: string, chat: any): Promise<void> {
+        const key = this.chatSyncKey(chaId, chatId)
+        const previous = this.chatSaveTails.get(key) ?? Promise.resolve()
+        const operation = previous
+            .catch(() => undefined)
+            .then(() => this.saveChatContentSerialized(chaId, chatIndex, chatId, chat))
+        this.chatSaveTails.set(key, operation)
+        try {
+            await operation
+        }
+        finally {
+            if (this.chatSaveTails.get(key) === operation) {
+                this.chatSaveTails.delete(key)
+            }
+        }
+    }
+
+    private async saveChatContentSerialized(
+        chaId: string,
+        chatIndex: number,
+        chatId: string,
+        chat: any,
+    ): Promise<void> {
         const encoded = encodeRisuSaveLegacy(chat)
-        const da = await this.authFetch(`/api/chat-content/${encodeURIComponent(chaId)}/${chatIndex}`, {
-            method: 'POST',
-            headers: {
-                'content-type': 'application/octet-stream',
-                'x-chat-id': chatId,
-            },
-            body: encoded,
-        })
+        const currentSnapshot = normalizeChat(await decodeRisuSave(encoded))
+        if (currentSnapshot?.id !== chatId || !Array.isArray(currentSnapshot?.message)) {
+            throw new Error('Refusing to save an invalid or mismatched chat')
+        }
+
+        const syncKey = this.chatSyncKey(chaId, chatId)
+        let syncState = this.chatSyncStates.get(syncKey)
+        let createOnly = false
+
+        // A missing revision is not permission to overwrite an existing chat.
+        // Existing chats are first fetched to seed a delta/CAS baseline. Only
+        // an authoritative 404 enables a create-only full save below.
+        if (!syncState?.revision) {
+            let serverSnapshot: ServerChatSnapshot | null
+            try {
+                serverSnapshot = await this.readServerChatSnapshot(chaId, chatIndex, chatId)
+            }
+            catch (error) {
+                throw new ChatConflictError(
+                    `Could not establish a safe chat save baseline: ${String(error)}`,
+                    error instanceof ChatConflictError ? error.currentRevision : null,
+                )
+            }
+            if (serverSnapshot) {
+                this.rememberChatSyncState(
+                    syncKey,
+                    serverSnapshot.revision,
+                    serverSnapshot.chat,
+                    serverSnapshot.encodedBytes,
+                )
+                this.chatDeltaSupported = true
+                syncState = this.chatSyncStates.get(syncKey)
+            }
+            else {
+                createOnly = true
+            }
+        }
+        if (
+            syncState?.snapshot
+            && this.chatDeltaSupported !== false
+            && isPlainJsonValue(currentSnapshot)
+        ) {
+            const { compare } = await import('fast-json-patch')
+            const patch = compare(syncState.snapshot, currentSnapshot)
+            if (patch.length === 0) return
+
+            const deltaBody = JSON.stringify({
+                baseRevision: syncState.revision,
+                patch,
+            })
+            const deltaBytes = Buffer.byteLength(deltaBody, 'utf-8')
+            const deltaIsWorthwhile = deltaBytes <= 1_500_000
+                && deltaBytes < encoded.byteLength * 0.8
+
+            if (deltaIsWorthwhile) {
+                let deltaResponse: Response
+                try {
+                    deltaResponse = await this.authFetch(
+                        `/api/chat-content/${encodeURIComponent(chaId)}/${chatIndex}/patch`,
+                        {
+                            method: 'POST',
+                            headers: {
+                                'content-type': 'application/json',
+                                'x-chat-id': chatId,
+                            },
+                            body: deltaBody,
+                        },
+                    )
+                }
+                catch (error) {
+                    // The server may have committed before the connection was
+                    // lost. Confirm the desired snapshot with a fresh GET; if it
+                    // matches, the missing response was only a lost ACK.
+                    const confirmation = await this.confirmCurrentSnapshotOnServer(
+                        chaId,
+                        chatIndex,
+                        chatId,
+                        currentSnapshot,
+                        encoded.byteLength,
+                    )
+                    if (confirmation.confirmed) return
+                    throw new ChatConflictError(
+                        `Incremental chat save could not be confirmed: ${String(error)}`,
+                        confirmation.currentRevision ?? syncState.revision,
+                    )
+                }
+
+                const deltaResult = await deltaResponse.clone().json().catch(() => ({}))
+                if (deltaResponse.status >= 200 && deltaResponse.status < 300) {
+                    const revision = this.chatRevisionFromResponse(deltaResponse, deltaResult)
+                    if (revision) {
+                        this.rememberChatSyncState(
+                            syncKey,
+                            revision,
+                            currentSnapshot,
+                            encoded.byteLength,
+                        )
+                    }
+                    else {
+                        this.forgetChatSyncState(syncKey)
+                    }
+                    this.chatDeltaSupported = true
+                    return
+                }
+                if (deltaResponse.status === 409 || deltaResponse.status === 404) {
+                    if (deltaResponse.status === 409) {
+                        const confirmation = await this.confirmCurrentSnapshotOnServer(
+                            chaId,
+                            chatIndex,
+                            chatId,
+                            currentSnapshot,
+                            encoded.byteLength,
+                        )
+                        if (confirmation.confirmed) return
+                        throw new ChatConflictError(
+                            deltaResult?.error || 'Chat changed on the server',
+                            confirmation.currentRevision
+                                ?? this.chatRevisionFromResponse(deltaResponse, deltaResult),
+                        )
+                    }
+                    throw new ChatConflictError(
+                        'Chat was removed or replaced on the server',
+                        this.chatRevisionFromResponse(deltaResponse, deltaResult),
+                    )
+                }
+                if (deltaResponse.status === 405 || deltaResponse.status === 501) {
+                    // Older servers can still accept the full endpoint. Keep the
+                    // base revision header so compatible servers retain CAS.
+                    this.chatDeltaSupported = false
+                }
+                else if (deltaResponse.status !== 400 && deltaResponse.status !== 413) {
+                    throw new Error(`saveChatContent patch error: ${deltaResponse.status}`)
+                }
+            }
+        }
+
+        const headers: Record<string, string> = {
+            'content-type': 'application/octet-stream',
+            'x-chat-id': chatId,
+        }
+        if (syncState?.revision) {
+            headers['x-chat-base-revision'] = syncState.revision
+        }
+        else if (createOnly) {
+            headers['if-none-match'] = '*'
+        }
+        let da: Response
+        try {
+            da = await this.authFetch(`/api/chat-content/${encodeURIComponent(chaId)}/${chatIndex}`, {
+                method: 'POST',
+                headers,
+                body: encoded,
+            })
+        }
+        catch (error) {
+            const confirmation = await this.confirmCurrentSnapshotOnServer(
+                chaId,
+                chatIndex,
+                chatId,
+                currentSnapshot,
+                encoded.byteLength,
+            )
+            if (confirmation.confirmed) return
+            throw new ChatConflictError(
+                `Full chat save could not be confirmed: ${String(error)}`,
+                confirmation.currentRevision ?? syncState?.revision ?? null,
+            )
+        }
+        const result = await da.clone().json().catch(() => ({}))
+        if (da.status === 409 || da.status === 412) {
+            const confirmation = await this.confirmCurrentSnapshotOnServer(
+                chaId,
+                chatIndex,
+                chatId,
+                currentSnapshot,
+                encoded.byteLength,
+            )
+            if (confirmation.confirmed) return
+            throw new ChatConflictError(
+                result?.error || 'Chat changed on the server',
+                confirmation.currentRevision ?? this.chatRevisionFromResponse(da, result),
+            )
+        }
         if (da.status < 200 || da.status >= 300) throw new Error(`saveChatContent error: ${da.status}`)
+        const revision = this.chatRevisionFromResponse(da, result)
+        if (revision) {
+            this.rememberChatSyncState(
+                syncKey,
+                revision,
+                currentSnapshot,
+                encoded.byteLength,
+            )
+            this.chatDeltaSupported = true
+        }
+        else {
+            this.forgetChatSyncState(syncKey)
+            this.chatDeltaSupported = false
+        }
     }
 
     // ── Save-folder migration ─────────────────────────────────────────────────
@@ -677,7 +1282,9 @@ export class NodeStorage{
             const body = await da.json().catch(() => ({}))
             throw new Error(body.error || `import error: ${da.status}`)
         }
-        return da.json()
+        const result = await da.json()
+        await this.invalidateAfterDatabaseReplacement()
+        return result
     }
 
     async uploadSaveFolderZip(
@@ -686,7 +1293,7 @@ export class NodeStorage{
     ): Promise<{ok: boolean, imported: number}> {
         const authHeader = await this.createAuth()
 
-        return await new Promise((resolve, reject) => {
+        const result = await new Promise<{ok: boolean, imported: number}>((resolve, reject) => {
             const xhr = new XMLHttpRequest()
             xhr.open('POST', '/api/migrate/save-folder/upload')
             xhr.setRequestHeader('content-type', 'application/zip')
@@ -716,6 +1323,8 @@ export class NodeStorage{
 
             xhr.send(file)
         })
+        await this.invalidateAfterDatabaseReplacement()
+        return result
     }
 
     async scanCleanup(): Promise<{count: number, totalSize: number}> {

--- a/src/ts/storage/risuSave.ts
+++ b/src/ts/storage/risuSave.ts
@@ -873,6 +873,11 @@ export class RisuSavePatcher {
         return (rootHash >>> 0).toString(16);
     }
 
+    /** Return the last server-confirmed JSON baseline for conflict rebasing. */
+    baselineSnapshot(): any {
+        return normalizeJSON(this.lastSyncedDb)
+    }
+
     async init(data: any) {
         this.lastSyncedDb = normalizeJSON(data);
         if (!Array.isArray(this.lastSyncedDb.characters)) {
@@ -924,7 +929,54 @@ export class RisuSavePatcher {
         }
     }
 
-    async set(data: any, toSave: toSaveType): Promise<{ patch: any[]; expectedHash: string }> {
+    async set(data: any, toSave: toSaveType): Promise<{
+        patch: any[]
+        expectedHash: string
+        /** Restore the baseline when the server does not accept this patch. */
+        rollback: () => void
+    }> {
+        // set() historically advanced the local baseline before the server
+        // accepted the patch. A 409/network error therefore made the retry use
+        // a hash for data the server never stored, often cascading into an
+        // unsafe full-write fallback. Detach the mutable state cheaply (the
+        // method replaces array entries rather than mutating their children)
+        // and expose a rollback for the persistence layer.
+        const previousState = {
+            lastSyncedDb: this.lastSyncedDb,
+            hashBlocks: this.hashBlocks,
+            lastRootKeyJsons: this.lastRootKeyJsons,
+            lastCharJsons: this.lastCharJsons,
+            lastModuleJsons: this.lastModuleJsons,
+            moduleItemHashes: this.moduleItemHashes,
+        }
+        this.lastSyncedDb = {
+            ...this.lastSyncedDb,
+            characters: Array.isArray(this.lastSyncedDb?.characters)
+                ? [...this.lastSyncedDb.characters]
+                : [],
+            modules: Array.isArray(this.lastSyncedDb?.modules)
+                ? [...this.lastSyncedDb.modules]
+                : this.lastSyncedDb?.modules,
+        }
+        this.hashBlocks = { ...this.hashBlocks }
+        this.lastRootKeyJsons = new Map(this.lastRootKeyJsons)
+        this.lastCharJsons = new Map(this.lastCharJsons)
+        this.lastModuleJsons = new Map(this.lastModuleJsons)
+        this.moduleItemHashes = new Map(this.moduleItemHashes)
+
+        let canRollback = true
+        const rollback = () => {
+            if (!canRollback) return
+            canRollback = false
+            this.lastSyncedDb = previousState.lastSyncedDb
+            this.hashBlocks = previousState.hashBlocks
+            this.lastRootKeyJsons = previousState.lastRootKeyJsons
+            this.lastCharJsons = previousState.lastCharJsons
+            this.lastModuleJsons = previousState.lastModuleJsons
+            this.moduleItemHashes = previousState.moduleItemHashes
+        }
+
+        try {
         const { compare } = await import('fast-json-patch')
         const expectedHash: string = this.hash();
         const patch: any[] = []
@@ -1164,7 +1216,13 @@ export class RisuSavePatcher {
 
         return {
             patch,
-            expectedHash
+            expectedHash,
+            rollback,
+        }
+        }
+        catch (error) {
+            rollback()
+            throw error
         }
     }
 }

--- a/src/ts/storage/risuSavePatcher.test.ts
+++ b/src/ts/storage/risuSavePatcher.test.ts
@@ -1076,3 +1076,29 @@ describe('fast-path — per-module granularity', () => {
         expect(liveHash).toBe(freshHash)
     })
 })
+
+describe('RisuSavePatcher.set acknowledgement boundary', () => {
+    test('rollback restores the previous hash and diff baseline after a rejected patch', async () => {
+        const db = dbWith([chr('a')])
+        const changed = clone(db)
+        changed.personaPrompt = 'changed after the initial sync'
+
+        const patcher = new RisuSavePatcher()
+        await patcher.init(clone(db))
+
+        const first = await patcher.set(clone(changed), { ...emptyToSave(), root: true })
+        expect(first.patch.length).toBeGreaterThan(0)
+
+        first.rollback()
+        first.rollback() // idempotent for catch/finally callers
+
+        const retry = await patcher.set(clone(changed), { ...emptyToSave(), root: true })
+        expect(retry.expectedHash).toBe(first.expectedHash)
+        expect(retry.patch).toEqual(first.patch)
+
+        // Leaving the second prepared patch in place represents a successful
+        // acknowledgement; the next identical save should then be a no-op.
+        const afterAcknowledgement = await patcher.set(clone(changed), { ...emptyToSave(), root: true })
+        expect(afterAcknowledgement.patch).toEqual([])
+    })
+})

--- a/src/ts/storage/startupDatabaseCache.test.ts
+++ b/src/ts/storage/startupDatabaseCache.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it } from 'vitest'
+import {
+    DEFAULT_STARTUP_DATABASE_CACHE_LIMITS,
+    DEFAULT_STARTUP_DATABASE_CACHE_OPERATION_TIMEOUT_MS,
+    STARTUP_DATABASE_CACHE_FORMAT_VERSION,
+    StartupDatabaseCache,
+    appendStartupDatabasePatch,
+    createStartupDatabaseCacheNamespace,
+    jsonByteLength,
+    type StartupDatabaseCacheMeta,
+    type StartupDatabaseCacheRecord,
+    type StartupDecodedCacheStore,
+    type StartupRawCacheMetadata,
+    type StartupRawCacheStore,
+} from './startupDatabaseCache'
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+async function settleBeforeTestDeadline<T>(promise: Promise<T>): Promise<T> {
+    return Promise.race([
+        promise,
+        sleep(250).then(() => {
+            throw new Error('cache operation exceeded the test deadline')
+        }),
+    ])
+}
+
+class MemoryRawStore implements StartupRawCacheStore {
+    metadataReads = 0
+    bodyReads = 0
+    clears = 0
+    writes: string[] = []
+    etag = ''
+    bytes: Uint8Array | null = null
+
+    constructor(readonly namespace: string) { }
+
+    async readMetadata(): Promise<StartupRawCacheMetadata | null> {
+        this.metadataReads += 1
+        return this.etag ? { namespace: this.namespace, etag: this.etag } : null
+    }
+
+    async readBytes(expectedEtag: string): Promise<Uint8Array | null> {
+        this.bodyReads += 1
+        return this.etag === expectedEtag ? this.bytes?.slice() ?? null : null
+    }
+
+    async write(etag: string, bytes: Uint8Array): Promise<boolean> {
+        this.writes.push(`start:${etag}`)
+        if (etag === 'slow') await sleep(20)
+        this.etag = etag
+        this.bytes = bytes.slice()
+        this.writes.push(`end:${etag}`)
+        return true
+    }
+
+    async clear(): Promise<void> {
+        this.clears += 1
+        this.etag = ''
+        this.bytes = null
+    }
+}
+
+class MemoryDecodedStore implements StartupDecodedCacheStore {
+    metaReads = 0
+    recordReads = 0
+    clears = 0
+    meta: StartupDatabaseCacheMeta | null = null
+    record: StartupDatabaseCacheRecord | null = null
+
+    async readMeta(): Promise<StartupDatabaseCacheMeta | null> {
+        this.metaReads += 1
+        return this.meta ? structuredClone(this.meta) : null
+    }
+
+    async readRecord(): Promise<StartupDatabaseCacheRecord | null> {
+        this.recordReads += 1
+        return this.record ? structuredClone(this.record) : null
+    }
+
+    async writeBaseline(
+        record: StartupDatabaseCacheRecord,
+        meta: StartupDatabaseCacheMeta,
+    ): Promise<boolean> {
+        this.record = structuredClone(record)
+        this.meta = structuredClone(meta)
+        return true
+    }
+
+    async writeMeta(meta: StartupDatabaseCacheMeta): Promise<boolean> {
+        this.meta = structuredClone(meta)
+        return true
+    }
+
+    async clear(): Promise<void> {
+        this.clears += 1
+        this.meta = null
+        this.record = null
+    }
+}
+
+function neverSettles<T>(): Promise<T> {
+    return new Promise<T>(() => { })
+}
+
+class NeverSettlingRawStore implements StartupRawCacheStore {
+    readMetadata(): Promise<StartupRawCacheMetadata | null> { return neverSettles() }
+    readBytes(): Promise<Uint8Array | null> { return neverSettles() }
+    write(): Promise<boolean> { return neverSettles() }
+    clear(): Promise<void> { return neverSettles() }
+}
+
+class NeverSettlingDecodedStore implements StartupDecodedCacheStore {
+    readMeta(): Promise<StartupDatabaseCacheMeta | null> { return neverSettles() }
+    readRecord(): Promise<StartupDatabaseCacheRecord | null> { return neverSettles() }
+    writeBaseline(): Promise<boolean> { return neverSettles() }
+    writeMeta(): Promise<boolean> { return neverSettles() }
+    clear(): Promise<void> { return neverSettles() }
+}
+
+function createMemoryCache(options?: {
+    appVersion?: string
+    schemaEpoch?: string | number
+    limits?: { maxPatches?: number, maxPatchBytes?: number }
+}) {
+    const appVersion = options?.appVersion ?? '1.8.1'
+    const schemaEpoch = options?.schemaEpoch ?? 7
+    const namespace = createStartupDatabaseCacheNamespace(appVersion, schemaEpoch)
+    const raw = new MemoryRawStore(namespace)
+    const decoded = new MemoryDecodedStore()
+    const cache = new StartupDatabaseCache({
+        appVersion,
+        schemaEpoch,
+        limits: options?.limits,
+        rawStore: raw,
+        decodedStore: decoded,
+    })
+    return { cache, raw, decoded, namespace }
+}
+
+function baselineMeta(namespace: string, etag = 'e1'): StartupDatabaseCacheMeta {
+    return {
+        formatVersion: STARTUP_DATABASE_CACHE_FORMAT_VERSION,
+        namespace,
+        baseEtag: etag,
+        currentEtag: etag,
+        patches: [],
+        patchBytes: 0,
+    }
+}
+
+describe('startup database cache helpers', () => {
+    it('derives the namespace from app version and schema epoch', () => {
+        const a = createStartupDatabaseCacheNamespace('1.8.1', 7)
+        expect(a).toContain('app:1.8.1')
+        expect(a).toContain('schema:7')
+        expect(createStartupDatabaseCacheNamespace('1.8.2', 7)).not.toBe(a)
+        expect(createStartupDatabaseCacheNamespace('1.8.1', 8)).not.toBe(a)
+    })
+
+    it('appends a bounded patch journal and advances its ETag', () => {
+        const namespace = createStartupDatabaseCacheNamespace('1.8.1', 7)
+        const patch = [{ op: 'replace', path: '/name', value: 'next' }]
+        const result = appendStartupDatabasePatch(baselineMeta(namespace), {
+            namespace,
+            previousEtag: 'e1',
+            nextEtag: 'e2',
+            patch,
+        })
+
+        expect(result.kind).toBe('updated')
+        if (result.kind !== 'updated') return
+        expect(result.meta.currentEtag).toBe('e2')
+        expect(result.meta.patches).toEqual([patch])
+        expect(result.meta.patchBytes).toBe(jsonByteLength(patch))
+    })
+
+    it('invalidates on ETag mismatch, patch-count cap, and byte cap', () => {
+        const namespace = createStartupDatabaseCacheNamespace('1.8.1', 7)
+        const patch = [{ op: 'replace', path: '/name', value: 'next' }]
+        const meta = baselineMeta(namespace)
+
+        expect(appendStartupDatabasePatch(meta, {
+            namespace,
+            previousEtag: 'wrong',
+            nextEtag: 'e2',
+            patch,
+        }).kind).toBe('invalidate')
+
+        expect(appendStartupDatabasePatch(meta, {
+            namespace,
+            previousEtag: 'e1',
+            nextEtag: 'e2',
+            patch,
+        }, { maxPatches: 0, maxPatchBytes: Number.MAX_SAFE_INTEGER }).kind).toBe('invalidate')
+
+        expect(appendStartupDatabasePatch(meta, {
+            namespace,
+            previousEtag: 'e1',
+            nextEtag: 'e2',
+            patch,
+        }, { maxPatches: 1, maxPatchBytes: jsonByteLength(patch) - 1 }).kind).toBe('invalidate')
+    })
+
+    it('uses the requested production caps by default', () => {
+        expect(DEFAULT_STARTUP_DATABASE_CACHE_LIMITS).toEqual({
+            maxPatches: 200,
+            maxPatchBytes: 4 * 1024 * 1024,
+        })
+        expect(DEFAULT_STARTUP_DATABASE_CACHE_OPERATION_TIMEOUT_MS).toBe(1500)
+    })
+})
+
+describe('StartupDatabaseCache probe and hydration', () => {
+    it('probes metadata without reading decoded objects or raw bodies', async () => {
+        const { cache, raw, decoded, namespace } = createMemoryCache()
+        decoded.meta = baselineMeta(namespace, 'decoded-etag')
+        decoded.record = {
+            formatVersion: 1,
+            namespace,
+            baseEtag: 'decoded-etag',
+            database: { name: 'cached' },
+        }
+        raw.etag = 'raw-etag'
+        raw.bytes = new Uint8Array([1, 2, 3])
+
+        await expect(cache.probe()).resolves.toEqual({ etag: 'decoded-etag', source: 'decoded' })
+        expect(decoded.recordReads).toBe(0)
+        expect(raw.bodyReads).toBe(0)
+    })
+
+    it('hydrates and replays the decoded journal only after 304', async () => {
+        const { cache, decoded, namespace } = createMemoryCache()
+        const patch = [{ op: 'replace', path: '/characters/0/name', value: 'after' }]
+        decoded.meta = {
+            ...baselineMeta(namespace, 'e1'),
+            currentEtag: 'e2',
+            patches: [patch],
+            patchBytes: jsonByteLength(patch),
+        }
+        decoded.record = {
+            formatVersion: 1,
+            namespace,
+            baseEtag: 'e1',
+            database: { characters: [{ name: 'before' }] },
+        }
+
+        const probe = await cache.probe()
+        expect(probe?.etag).toBe('e2')
+        expect(decoded.recordReads).toBe(0)
+
+        await expect(cache.resolveNotModified('e2')).resolves.toEqual({
+            kind: 'decoded',
+            etag: 'e2',
+            database: { characters: [{ name: 'after' }] },
+        })
+        expect(decoded.recordReads).toBe(1)
+    })
+
+    it('clears corrupt decoded data and falls back to exact-ETag raw bytes', async () => {
+        const { cache, raw, decoded, namespace } = createMemoryCache()
+        decoded.meta = baselineMeta(namespace, 'e1')
+        decoded.record = {
+            formatVersion: 1,
+            namespace: 'wrong-build',
+            baseEtag: 'e1',
+            database: { stale: true },
+        }
+        raw.etag = 'e1'
+        raw.bytes = new Uint8Array([4, 5, 6])
+
+        const hit = await cache.resolveNotModified('e1')
+        expect(hit).toEqual({ kind: 'raw', etag: 'e1', bytes: new Uint8Array([4, 5, 6]) })
+        expect(decoded.clears).toBe(1)
+    })
+
+    it('invalidates app/schema-mismatched decoded metadata', async () => {
+        const { cache, decoded } = createMemoryCache({ appVersion: '1.8.2', schemaEpoch: 8 })
+        decoded.meta = baselineMeta(createStartupDatabaseCacheNamespace('1.8.1', 7), 'old')
+
+        await expect(cache.probe()).resolves.toBeNull()
+        expect(decoded.clears).toBe(1)
+    })
+
+    it('clears raw bytes rejected by the caller decoder', async () => {
+        const { cache, raw } = createMemoryCache()
+        raw.etag = 'e1'
+        raw.bytes = new Uint8Array([255])
+
+        await expect(cache.resolveNotModified('e1', {
+            validateRaw: () => false,
+        })).resolves.toBeNull()
+        expect(raw.clears).toBe(1)
+    })
+})
+
+describe('StartupDatabaseCache mutations', () => {
+    it('stores an authoritative raw body and decoded baseline', async () => {
+        const { cache, raw, decoded, namespace } = createMemoryCache()
+        const result = await cache.storeAuthoritative({
+            etag: 'e1',
+            bytes: new Uint8Array([1, 2, 3]),
+            decoded: { characters: [] },
+        })
+
+        expect(result).toEqual({ rawStored: true, decodedStored: true })
+        expect(raw.etag).toBe('e1')
+        expect(decoded.meta).toEqual(baselineMeta(namespace, 'e1'))
+        expect(decoded.record?.database).toEqual({ characters: [] })
+    })
+
+    it('serializes writes so a slow old body cannot overwrite a newer one', async () => {
+        const { cache, raw } = createMemoryCache()
+        const slow = cache.storeAuthoritative({ etag: 'slow', bytes: new Uint8Array([1]) })
+        const fresh = cache.storeAuthoritative({ etag: 'fresh', bytes: new Uint8Array([2]) })
+        await Promise.all([slow, fresh])
+
+        expect(raw.writes).toEqual(['start:slow', 'end:slow', 'start:fresh', 'end:fresh'])
+        expect(raw.etag).toBe('fresh')
+        expect(raw.bytes).toEqual(new Uint8Array([2]))
+    })
+
+    it('records patches and clears the decoded cache at its configured cap', async () => {
+        const { cache, decoded, namespace } = createMemoryCache({
+            limits: { maxPatches: 1, maxPatchBytes: 1024 },
+        })
+        decoded.meta = baselineMeta(namespace, 'e1')
+        decoded.record = {
+            formatVersion: 1,
+            namespace,
+            baseEtag: 'e1',
+            database: { value: 0 },
+        }
+
+        await expect(cache.recordPatch({
+            previousEtag: 'e1',
+            nextEtag: 'e2',
+            patch: [{ op: 'replace', path: '/value', value: 1 }],
+        })).resolves.toBe('recorded')
+        await expect(cache.recordPatch({
+            previousEtag: 'e2',
+            nextEtag: 'e3',
+            patch: [{ op: 'replace', path: '/value', value: 2 }],
+        })).resolves.toBe('invalidated')
+        expect(decoded.meta).toBeNull()
+        expect(decoded.record).toBeNull()
+    })
+
+    it('treats unavailable or quota-failing stores as a cache miss', async () => {
+        const failingRaw: StartupRawCacheStore = {
+            async readMetadata() { throw new Error('unavailable') },
+            async readBytes() { throw new Error('unavailable') },
+            async write() { throw new DOMException('quota', 'QuotaExceededError') },
+            async clear() { throw new Error('unavailable') },
+        }
+        const failingDecoded: StartupDecodedCacheStore = {
+            async readMeta() { throw new Error('unavailable') },
+            async readRecord() { throw new Error('unavailable') },
+            async writeBaseline() { throw new DOMException('quota', 'QuotaExceededError') },
+            async writeMeta() { throw new DOMException('quota', 'QuotaExceededError') },
+            async clear() { throw new Error('unavailable') },
+        }
+        const cache = new StartupDatabaseCache({
+            appVersion: '1.8.1',
+            schemaEpoch: 7,
+            rawStore: failingRaw,
+            decodedStore: failingDecoded,
+        })
+
+        await expect(cache.probe()).resolves.toBeNull()
+        await expect(cache.storeAuthoritative({
+            etag: 'e1',
+            bytes: new Uint8Array([1]),
+            decoded: { ok: true },
+        })).resolves.toEqual({ rawStored: false, decodedStored: false })
+        await expect(cache.invalidate()).resolves.toBeUndefined()
+    })
+
+    it('bounds probe, resolve, and invalidate when browser storage never responds', async () => {
+        const cache = new StartupDatabaseCache({
+            appVersion: '1.8.1',
+            schemaEpoch: 7,
+            operationTimeoutMs: 10,
+            rawStore: new NeverSettlingRawStore(),
+            decodedStore: new NeverSettlingDecodedStore(),
+        })
+
+        await expect(settleBeforeTestDeadline(cache.probe())).resolves.toBeNull()
+        await expect(settleBeforeTestDeadline(cache.resolveNotModified('e1'))).resolves.toBeNull()
+        await expect(settleBeforeTestDeadline(cache.invalidate())).resolves.toBeUndefined()
+    })
+
+    it('does not let a permanently pending mutation tail block a later probe', async () => {
+        const cache = new StartupDatabaseCache({
+            appVersion: '1.8.1',
+            schemaEpoch: 7,
+            operationTimeoutMs: 10,
+            rawStore: new NeverSettlingRawStore(),
+            decodedStore: new MemoryDecodedStore(),
+        })
+
+        void cache.storeAuthoritative({
+            etag: 'never-finishes',
+            bytes: new Uint8Array([1]),
+            decoded: { ok: true },
+        })
+
+        await expect(settleBeforeTestDeadline(cache.probe())).resolves.toBeNull()
+    })
+})

--- a/src/ts/storage/startupDatabaseCache.ts
+++ b/src/ts/storage/startupDatabaseCache.ts
@@ -1,0 +1,725 @@
+import { applyPatch } from 'fast-json-patch'
+
+export const STARTUP_DATABASE_CACHE_FORMAT_VERSION = 1
+
+export const DEFAULT_STARTUP_DATABASE_CACHE_LIMITS = Object.freeze({
+    maxPatches: 200,
+    maxPatchBytes: 4 * 1024 * 1024,
+})
+
+export const DEFAULT_STARTUP_DATABASE_CACHE_OPERATION_TIMEOUT_MS = 1500
+
+export interface JsonPatchOperation {
+    op: string
+    path: string
+    from?: string
+    value?: unknown
+}
+
+export interface StartupDatabaseCacheLimits {
+    maxPatches: number
+    maxPatchBytes: number
+}
+
+export interface StartupDatabaseCacheMeta {
+    formatVersion: 1
+    namespace: string
+    baseEtag: string
+    currentEtag: string
+    patches: JsonPatchOperation[][]
+    patchBytes: number
+}
+
+export interface StartupDatabaseCacheRecord {
+    formatVersion: 1
+    namespace: string
+    baseEtag: string
+    database: unknown
+}
+
+export interface StartupRawCacheMetadata {
+    namespace: string
+    etag: string
+}
+
+export interface StartupRawCacheStore {
+    readMetadata(): Promise<StartupRawCacheMetadata | null>
+    readBytes(expectedEtag: string): Promise<Uint8Array | null>
+    write(etag: string, bytes: Uint8Array): Promise<boolean>
+    clear(): Promise<void>
+}
+
+export interface StartupDecodedCacheStore {
+    readMeta(): Promise<StartupDatabaseCacheMeta | null>
+    readRecord(): Promise<StartupDatabaseCacheRecord | null>
+    writeBaseline(record: StartupDatabaseCacheRecord, meta: StartupDatabaseCacheMeta): Promise<boolean>
+    writeMeta(meta: StartupDatabaseCacheMeta): Promise<boolean>
+    clear(): Promise<void>
+}
+
+export interface StartupDatabaseCacheOptions {
+    appVersion: string
+    schemaEpoch: string | number
+    /**
+     * Maximum time a startup-critical cache operation may delay the
+     * authoritative server path. Primarily exposed so tests can use a much
+     * shorter bound.
+     */
+    operationTimeoutMs?: number
+    origin?: string
+    limits?: Partial<StartupDatabaseCacheLimits>
+    cacheStorage?: CacheStorage | null
+    indexedDB?: IDBFactory | null
+    rawStore?: StartupRawCacheStore | null
+    decodedStore?: StartupDecodedCacheStore | null
+}
+
+export interface StartupDatabaseCacheProbe {
+    etag: string
+    source: 'decoded' | 'raw'
+}
+
+export type StartupDatabaseCacheHit =
+    | { kind: 'decoded', etag: string, database: unknown }
+    | { kind: 'raw', etag: string, bytes: Uint8Array }
+
+export interface StoreAuthoritativeDatabaseInput {
+    etag: string
+    bytes: Uint8Array
+    decoded?: unknown
+}
+
+export interface StoreAuthoritativeDatabaseResult {
+    rawStored: boolean
+    decodedStored: boolean
+}
+
+export type RecordStartupDatabasePatchResult = 'recorded' | 'invalidated' | 'skipped'
+
+export type AppendPatchJournalResult =
+    | { kind: 'updated', meta: StartupDatabaseCacheMeta }
+    | { kind: 'invalidate', reason: 'namespace' | 'etag' | 'shape' | 'limit' }
+
+const RAW_CACHE_NAME = 'pocketrisu-startup-database-cache-v1'
+const RAW_CACHE_PATH_PREFIX = '/__pocketrisu-cache__/database/'
+const RAW_ETAG_HEADER = 'x-db-etag'
+const RAW_NAMESPACE_HEADER = 'x-pocketrisu-cache-namespace'
+const RAW_FORMAT_HEADER = 'x-pocketrisu-cache-format'
+const DECODED_CACHE_DB_NAME = 'pocketrisu-startup-database-cache-v1'
+const DECODED_CACHE_STORE_NAME = 'startup-database'
+const DECODED_CACHE_META_KEY = 'meta'
+const DECODED_CACHE_RECORD_KEY = 'record'
+
+function normalizeNamespacePart(value: string | number): string {
+    const normalized = String(value).trim()
+    return normalized || 'unknown'
+}
+
+/**
+ * Cache identity deliberately includes both the application build and the
+ * decoder/schema epoch. A new decoder must never hydrate an object produced by
+ * an older build merely because the authoritative bytes still have the same
+ * ETag.
+ */
+export function createStartupDatabaseCacheNamespace(
+    appVersion: string,
+    schemaEpoch: string | number,
+): string {
+    return [
+        `format:${STARTUP_DATABASE_CACHE_FORMAT_VERSION}`,
+        `schema:${normalizeNamespacePart(schemaEpoch)}`,
+        `app:${normalizeNamespacePart(appVersion)}`,
+    ].join('|')
+}
+
+export function jsonByteLength(value: unknown): number {
+    try {
+        const encoded = JSON.stringify(value)
+        if (encoded === undefined) return Number.POSITIVE_INFINITY
+        return new TextEncoder().encode(encoded).byteLength
+    } catch {
+        return Number.POSITIVE_INFINITY
+    }
+}
+
+function isJsonPatchArray(value: unknown): value is JsonPatchOperation[][] {
+    return Array.isArray(value) && value.every((patch) =>
+        Array.isArray(patch) && patch.every((operation) =>
+            !!operation
+            && typeof operation === 'object'
+            && typeof (operation as JsonPatchOperation).op === 'string'
+            && typeof (operation as JsonPatchOperation).path === 'string'
+        )
+    )
+}
+
+export function isStartupDatabaseCacheMeta(
+    value: unknown,
+    namespace: string,
+): value is StartupDatabaseCacheMeta {
+    if (!value || typeof value !== 'object') return false
+    const meta = value as StartupDatabaseCacheMeta
+    if (
+        meta.formatVersion !== STARTUP_DATABASE_CACHE_FORMAT_VERSION
+        || meta.namespace !== namespace
+        || typeof meta.baseEtag !== 'string'
+        || !meta.baseEtag
+        || typeof meta.currentEtag !== 'string'
+        || !meta.currentEtag
+        || !isJsonPatchArray(meta.patches)
+        || !Number.isSafeInteger(meta.patchBytes)
+        || meta.patchBytes < 0
+    ) {
+        return false
+    }
+    return jsonByteLength(meta.patches) <= meta.patchBytes + meta.patches.length * 2
+        || meta.patches.length === 0
+}
+
+export function isStartupDatabaseCacheRecord(
+    value: unknown,
+    namespace: string,
+    baseEtag: string,
+): value is StartupDatabaseCacheRecord {
+    if (!value || typeof value !== 'object') return false
+    const record = value as StartupDatabaseCacheRecord
+    return record.formatVersion === STARTUP_DATABASE_CACHE_FORMAT_VERSION
+        && record.namespace === namespace
+        && record.baseEtag === baseEtag
+        && record.database !== null
+        && typeof record.database === 'object'
+}
+
+export function appendStartupDatabasePatch(
+    meta: StartupDatabaseCacheMeta,
+    input: {
+        namespace: string
+        previousEtag: string
+        nextEtag: string
+        patch: JsonPatchOperation[]
+    },
+    limits: StartupDatabaseCacheLimits = DEFAULT_STARTUP_DATABASE_CACHE_LIMITS,
+): AppendPatchJournalResult {
+    if (!isStartupDatabaseCacheMeta(meta, input.namespace)) {
+        return { kind: 'invalidate', reason: 'namespace' }
+    }
+    if (!input.previousEtag || !input.nextEtag || meta.currentEtag !== input.previousEtag) {
+        return { kind: 'invalidate', reason: 'etag' }
+    }
+    if (!isJsonPatchArray([input.patch])) {
+        return { kind: 'invalidate', reason: 'shape' }
+    }
+
+    const bytes = jsonByteLength(input.patch)
+    if (!Number.isFinite(bytes)) {
+        return { kind: 'invalidate', reason: 'shape' }
+    }
+    if (
+        meta.patches.length + 1 > limits.maxPatches
+        || meta.patchBytes + bytes > limits.maxPatchBytes
+    ) {
+        return { kind: 'invalidate', reason: 'limit' }
+    }
+
+    return {
+        kind: 'updated',
+        meta: {
+            ...meta,
+            currentEtag: input.nextEtag,
+            patches: [...meta.patches, input.patch],
+            patchBytes: meta.patchBytes + bytes,
+        },
+    }
+}
+
+function quoteHttpEtag(etag: string): string {
+    return `"${etag.replaceAll('"', '')}"`
+}
+
+function cloneForCache(value: unknown): { ok: true, value: unknown } | { ok: false } {
+    try {
+        if (typeof structuredClone === 'function') {
+            return { ok: true, value: structuredClone(value) }
+        }
+        return { ok: true, value: JSON.parse(JSON.stringify(value)) }
+    } catch {
+        return { ok: false }
+    }
+}
+
+class NullRawCacheStore implements StartupRawCacheStore {
+    async readMetadata() { return null }
+    async readBytes() { return null }
+    async write() { return false }
+    async clear() { }
+}
+
+class NullDecodedCacheStore implements StartupDecodedCacheStore {
+    async readMeta() { return null }
+    async readRecord() { return null }
+    async writeBaseline() { return false }
+    async writeMeta() { return false }
+    async clear() { }
+}
+
+export class BrowserStartupRawCacheStore implements StartupRawCacheStore {
+    private readonly request: Request
+
+    constructor(
+        private readonly namespace: string,
+        origin: string,
+        private readonly cacheStorage: CacheStorage | null,
+    ) {
+        const path = `${RAW_CACHE_PATH_PREFIX}${encodeURIComponent(namespace)}.bin`
+        this.request = new Request(new URL(path, origin).toString())
+    }
+
+    private async open(): Promise<Cache | null> {
+        if (!this.cacheStorage) return null
+        try {
+            return await this.cacheStorage.open(RAW_CACHE_NAME)
+        } catch {
+            return null
+        }
+    }
+
+    private metadata(response: Response | undefined): StartupRawCacheMetadata | null {
+        if (!response) return null
+        const namespace = response.headers.get(RAW_NAMESPACE_HEADER) ?? ''
+        const etag = response.headers.get(RAW_ETAG_HEADER) ?? ''
+        const format = response.headers.get(RAW_FORMAT_HEADER)
+        if (
+            namespace !== this.namespace
+            || !etag
+            || format !== String(STARTUP_DATABASE_CACHE_FORMAT_VERSION)
+        ) {
+            return null
+        }
+        return { namespace, etag }
+    }
+
+    async readMetadata(): Promise<StartupRawCacheMetadata | null> {
+        const cache = await this.open()
+        if (!cache) return null
+        try {
+            const response = await cache.match(this.request)
+            const metadata = this.metadata(response)
+            if (!metadata && response) await cache.delete(this.request)
+            return metadata
+        } catch {
+            return null
+        }
+    }
+
+    async readBytes(expectedEtag: string): Promise<Uint8Array | null> {
+        const cache = await this.open()
+        if (!cache) return null
+        try {
+            const response = await cache.match(this.request)
+            const metadata = this.metadata(response)
+            if (!response || metadata?.etag !== expectedEtag) return null
+            const bytes = new Uint8Array(await response.arrayBuffer())
+            if (bytes.byteLength === 0) {
+                await cache.delete(this.request)
+                return null
+            }
+            return bytes
+        } catch {
+            return null
+        }
+    }
+
+    async write(etag: string, bytes: Uint8Array): Promise<boolean> {
+        if (!etag || bytes.byteLength === 0) return false
+        const cache = await this.open()
+        if (!cache) return false
+        try {
+            const response = new Response(bytes.slice() as BodyInit, {
+                headers: {
+                    'content-type': 'application/octet-stream',
+                    'etag': quoteHttpEtag(etag),
+                    [RAW_ETAG_HEADER]: etag,
+                    [RAW_NAMESPACE_HEADER]: this.namespace,
+                    [RAW_FORMAT_HEADER]: String(STARTUP_DATABASE_CACHE_FORMAT_VERSION),
+                },
+            })
+            await cache.put(this.request, response)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    async clear(): Promise<void> {
+        const cache = await this.open()
+        if (!cache) return
+        try {
+            await cache.delete(this.request)
+        } catch { }
+    }
+}
+
+export class BrowserStartupDecodedCacheStore implements StartupDecodedCacheStore {
+    constructor(private readonly factory: IDBFactory | null) { }
+
+    private async openDatabase(): Promise<IDBDatabase | null> {
+        if (!this.factory) return null
+        return new Promise((resolve) => {
+            let settled = false
+            const finish = (database: IDBDatabase | null) => {
+                if (settled) {
+                    database?.close()
+                    return
+                }
+                settled = true
+                resolve(database)
+            }
+            try {
+                const request = this.factory.open(DECODED_CACHE_DB_NAME, 1)
+                request.onupgradeneeded = () => {
+                    if (!request.result.objectStoreNames.contains(DECODED_CACHE_STORE_NAME)) {
+                        request.result.createObjectStore(DECODED_CACHE_STORE_NAME)
+                    }
+                }
+                request.onsuccess = () => finish(request.result)
+                request.onerror = () => finish(null)
+                request.onblocked = () => finish(null)
+            } catch {
+                finish(null)
+            }
+        })
+    }
+
+    private requestValue<T>(request: IDBRequest<T>): Promise<T | null> {
+        return new Promise((resolve) => {
+            request.onsuccess = () => resolve(request.result ?? null)
+            request.onerror = () => resolve(null)
+        })
+    }
+
+    private waitForTransaction(transaction: IDBTransaction): Promise<boolean> {
+        return new Promise((resolve) => {
+            transaction.oncomplete = () => resolve(true)
+            transaction.onerror = () => resolve(false)
+            transaction.onabort = () => resolve(false)
+        })
+    }
+
+    private async read<T>(key: string): Promise<T | null> {
+        const database = await this.openDatabase()
+        if (!database) return null
+        try {
+            const transaction = database.transaction(DECODED_CACHE_STORE_NAME, 'readonly')
+            return await this.requestValue<T>(transaction.objectStore(DECODED_CACHE_STORE_NAME).get(key))
+        } catch {
+            return null
+        } finally {
+            database.close()
+        }
+    }
+
+    async readMeta(): Promise<StartupDatabaseCacheMeta | null> {
+        return this.read<StartupDatabaseCacheMeta>(DECODED_CACHE_META_KEY)
+    }
+
+    async readRecord(): Promise<StartupDatabaseCacheRecord | null> {
+        return this.read<StartupDatabaseCacheRecord>(DECODED_CACHE_RECORD_KEY)
+    }
+
+    async writeBaseline(
+        record: StartupDatabaseCacheRecord,
+        meta: StartupDatabaseCacheMeta,
+    ): Promise<boolean> {
+        const database = await this.openDatabase()
+        if (!database) return false
+        try {
+            const transaction = database.transaction(DECODED_CACHE_STORE_NAME, 'readwrite')
+            const store = transaction.objectStore(DECODED_CACHE_STORE_NAME)
+            store.put(record, DECODED_CACHE_RECORD_KEY)
+            store.put(meta, DECODED_CACHE_META_KEY)
+            return await this.waitForTransaction(transaction)
+        } catch {
+            return false
+        } finally {
+            database.close()
+        }
+    }
+
+    async writeMeta(meta: StartupDatabaseCacheMeta): Promise<boolean> {
+        const database = await this.openDatabase()
+        if (!database) return false
+        try {
+            const transaction = database.transaction(DECODED_CACHE_STORE_NAME, 'readwrite')
+            transaction.objectStore(DECODED_CACHE_STORE_NAME).put(meta, DECODED_CACHE_META_KEY)
+            return await this.waitForTransaction(transaction)
+        } catch {
+            return false
+        } finally {
+            database.close()
+        }
+    }
+
+    async clear(): Promise<void> {
+        const database = await this.openDatabase()
+        if (!database) return
+        try {
+            const transaction = database.transaction(DECODED_CACHE_STORE_NAME, 'readwrite')
+            // Clear the object store instead of deleteDatabase. The latter can
+            // remain blocked forever while another PocketRisu tab is open.
+            transaction.objectStore(DECODED_CACHE_STORE_NAME).clear()
+            await this.waitForTransaction(transaction)
+        } catch { } finally {
+            database.close()
+        }
+    }
+}
+
+export class StartupDatabaseCache {
+    readonly namespace: string
+    readonly limits: StartupDatabaseCacheLimits
+    private readonly rawStore: StartupRawCacheStore
+    private readonly decodedStore: StartupDecodedCacheStore
+    private readonly operationTimeoutMs: number
+    private mutationTail: Promise<void> = Promise.resolve()
+
+    constructor(options: StartupDatabaseCacheOptions) {
+        this.namespace = createStartupDatabaseCacheNamespace(options.appVersion, options.schemaEpoch)
+        this.limits = {
+            maxPatches: Math.max(1, options.limits?.maxPatches ?? DEFAULT_STARTUP_DATABASE_CACHE_LIMITS.maxPatches),
+            maxPatchBytes: Math.max(1, options.limits?.maxPatchBytes ?? DEFAULT_STARTUP_DATABASE_CACHE_LIMITS.maxPatchBytes),
+        }
+        this.operationTimeoutMs = Number.isFinite(options.operationTimeoutMs)
+            ? Math.max(1, Math.floor(options.operationTimeoutMs!))
+            : DEFAULT_STARTUP_DATABASE_CACHE_OPERATION_TIMEOUT_MS
+
+        const origin = options.origin
+            ?? (typeof location !== 'undefined' ? location.origin : 'http://localhost')
+        const cacheStorage = options.cacheStorage === undefined
+            ? (typeof caches !== 'undefined' ? caches : null)
+            : options.cacheStorage
+        const indexedDbFactory = options.indexedDB === undefined
+            ? (typeof indexedDB !== 'undefined' ? indexedDB : null)
+            : options.indexedDB
+
+        this.rawStore = options.rawStore === undefined
+            ? new BrowserStartupRawCacheStore(this.namespace, origin, cacheStorage)
+            : (options.rawStore ?? new NullRawCacheStore())
+        this.decodedStore = options.decodedStore === undefined
+            ? new BrowserStartupDecodedCacheStore(indexedDbFactory)
+            : (options.decodedStore ?? new NullDecodedCacheStore())
+    }
+
+    private enqueueMutation<T>(operation: () => Promise<T>): Promise<T> {
+        const run = this.mutationTail.then(operation, operation)
+        this.mutationTail = run.then(() => undefined, () => undefined)
+        return run
+    }
+
+    /**
+     * Browser storage implementations can occasionally never dispatch their
+     * completion event (notably on mobile WebViews). A cache is optional, so a
+     * stuck operation must degrade to the supplied miss value instead of
+     * blocking startup forever. The original promise may still finish later;
+     * its rejection is observed by this handler.
+     */
+    private settleWithin<T>(operation: Promise<T>, fallback: T): Promise<T> {
+        return new Promise((resolve) => {
+            let settled = false
+            let timer: ReturnType<typeof globalThis.setTimeout> | undefined
+            const finish = (value: T) => {
+                if (settled) return
+                settled = true
+                if (timer !== undefined) globalThis.clearTimeout(timer)
+                resolve(value)
+            }
+            timer = globalThis.setTimeout(() => finish(fallback), this.operationTimeoutMs)
+            operation.then(finish, () => finish(fallback))
+        })
+    }
+
+    private async waitForMutations(): Promise<void> {
+        await this.mutationTail.catch(() => undefined)
+    }
+
+    private async clearDecodedBestEffort(): Promise<void> {
+        await this.settleWithin(this.enqueueMutation(async () => {
+            try { await this.decodedStore.clear() } catch { }
+        }), undefined)
+    }
+
+    private isUsableMeta(value: unknown): value is StartupDatabaseCacheMeta {
+        return isStartupDatabaseCacheMeta(value, this.namespace)
+            && value.patches.length <= this.limits.maxPatches
+            && value.patchBytes <= this.limits.maxPatchBytes
+    }
+
+    /**
+     * Reads only cache metadata. Callers should send the returned ETag to the
+     * server and call resolveNotModified only after an authenticated 304.
+     */
+    async probe(): Promise<StartupDatabaseCacheProbe | null> {
+        return this.settleWithin(this.probeWithoutTimeout(), null)
+    }
+
+    private async probeWithoutTimeout(): Promise<StartupDatabaseCacheProbe | null> {
+        await this.waitForMutations()
+        const [decodedMeta, rawMeta] = await Promise.all([
+            this.decodedStore.readMeta().catch(() => null),
+            this.rawStore.readMetadata().catch(() => null),
+        ])
+
+        if (decodedMeta) {
+            if (this.isUsableMeta(decodedMeta)) {
+                return { etag: decodedMeta.currentEtag, source: 'decoded' }
+            }
+            await this.clearDecodedBestEffort()
+        }
+        if (rawMeta?.namespace === this.namespace && rawMeta.etag) {
+            return { etag: rawMeta.etag, source: 'raw' }
+        }
+        return null
+    }
+
+    /**
+     * Hydrates cached content only after the server confirmed the exact ETag
+     * with 304. Invalid decoded data is cleared before trying the raw fallback.
+     */
+    async resolveNotModified(
+        etag: string,
+        options?: {
+            validateDecoded?: (database: unknown) => boolean | Promise<boolean>
+            validateRaw?: (bytes: Uint8Array) => boolean | Promise<boolean>
+        },
+    ): Promise<StartupDatabaseCacheHit | null> {
+        if (!etag) return null
+        return this.settleWithin(this.resolveNotModifiedWithoutTimeout(etag, options), null)
+    }
+
+    private async resolveNotModifiedWithoutTimeout(
+        etag: string,
+        options?: {
+            validateDecoded?: (database: unknown) => boolean | Promise<boolean>
+            validateRaw?: (bytes: Uint8Array) => boolean | Promise<boolean>
+        },
+    ): Promise<StartupDatabaseCacheHit | null> {
+        await this.waitForMutations()
+
+        const meta = await this.decodedStore.readMeta().catch(() => null)
+        if (meta) {
+            let decodedIsCorrupt = !this.isUsableMeta(meta)
+                || meta.currentEtag !== etag
+            if (!decodedIsCorrupt) {
+                const record = await this.decodedStore.readRecord().catch(() => null)
+                if (isStartupDatabaseCacheRecord(record, this.namespace, meta.baseEtag)) {
+                    try {
+                        let database = record.database
+                        for (const patch of meta.patches) {
+                            database = applyPatch(database as object, patch as any, true, false, true).newDocument
+                        }
+                        const valid = options?.validateDecoded
+                            ? await options.validateDecoded(database)
+                            : true
+                        if (valid) return { kind: 'decoded', etag, database }
+                    } catch { }
+                }
+                decodedIsCorrupt = true
+            }
+            if (decodedIsCorrupt) await this.clearDecodedBestEffort()
+        }
+
+        const bytes = await this.rawStore.readBytes(etag).catch(() => null)
+        if (!bytes || bytes.byteLength === 0) return null
+        let rawValid = true
+        if (options?.validateRaw) {
+            try {
+                rawValid = await options.validateRaw(bytes)
+            } catch {
+                rawValid = false
+            }
+        }
+        if (!rawValid) {
+            await this.settleWithin(this.enqueueMutation(async () => {
+                try { await this.rawStore.clear() } catch { }
+            }), undefined)
+            return null
+        }
+        return { kind: 'raw', etag, bytes }
+    }
+
+    async storeAuthoritative(
+        input: StoreAuthoritativeDatabaseInput,
+    ): Promise<StoreAuthoritativeDatabaseResult> {
+        if (!input.etag || !(input.bytes instanceof Uint8Array) || input.bytes.byteLength === 0) {
+            return { rawStored: false, decodedStored: false }
+        }
+        const bytes = input.bytes.slice()
+        const decodedClone = input.decoded === undefined ? null : cloneForCache(input.decoded)
+
+        return this.enqueueMutation(async () => {
+            let rawStored = false
+            let decodedStored = false
+            try { rawStored = await this.rawStore.write(input.etag, bytes) } catch { }
+
+            if (!decodedClone || !decodedClone.ok) {
+                try { await this.decodedStore.clear() } catch { }
+                return { rawStored, decodedStored }
+            }
+
+            const record: StartupDatabaseCacheRecord = {
+                formatVersion: STARTUP_DATABASE_CACHE_FORMAT_VERSION,
+                namespace: this.namespace,
+                baseEtag: input.etag,
+                database: decodedClone.value,
+            }
+            const meta: StartupDatabaseCacheMeta = {
+                formatVersion: STARTUP_DATABASE_CACHE_FORMAT_VERSION,
+                namespace: this.namespace,
+                baseEtag: input.etag,
+                currentEtag: input.etag,
+                patches: [],
+                patchBytes: 0,
+            }
+            try { decodedStored = await this.decodedStore.writeBaseline(record, meta) } catch { }
+            if (!decodedStored) {
+                try { await this.decodedStore.clear() } catch { }
+            }
+            return { rawStored, decodedStored }
+        })
+    }
+
+    async recordPatch(input: {
+        previousEtag: string
+        nextEtag: string
+        patch: JsonPatchOperation[]
+    }): Promise<RecordStartupDatabasePatchResult> {
+        if (!input.previousEtag || !input.nextEtag || !Array.isArray(input.patch)) return 'skipped'
+
+        return this.enqueueMutation(async () => {
+            const meta = await this.decodedStore.readMeta().catch(() => null)
+            if (!meta) return 'skipped'
+            const appended = appendStartupDatabasePatch(meta, {
+                namespace: this.namespace,
+                ...input,
+            }, this.limits)
+            if (appended.kind === 'invalidate') {
+                try { await this.decodedStore.clear() } catch { }
+                return 'invalidated'
+            }
+            const saved = await this.decodedStore.writeMeta(appended.meta).catch(() => false)
+            if (!saved) {
+                try { await this.decodedStore.clear() } catch { }
+                return 'invalidated'
+            }
+            return 'recorded'
+        })
+    }
+
+    async invalidate(): Promise<void> {
+        await this.settleWithin(this.enqueueMutation(async () => {
+            await Promise.all([
+                this.rawStore.clear().catch(() => undefined),
+                this.decodedStore.clear().catch(() => undefined),
+            ])
+        }), undefined)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a validated startup database cache and a conflict-safe lazy chat persistence path for the Node server build. It is intentionally submitted as one draft because the startup cache, chat payload split, revision protocol, durability journal, reconciliation logic, and plugin hydration boundary depend on one another for correctness.

The main goals are:

- avoid downloading and decoding an unchanged `database.bin` on every reload;
- keep large chat payloads out of routine database metadata synchronization;
- send small chat deltas when possible without allowing stale tabs to overwrite newer data;
- preserve acknowledged chat writes across server restarts and delayed metadata saves;
- ensure lazy placeholders are never exposed to plugins as real empty chats.

## Root causes

The original Node persistence path repeatedly moved and decoded the complete database, including chat history. Splitting chat payloads from `database.bin` reduces that cost, but introduces several consistency hazards:

- a chat payload can be acknowledged before its metadata stub is persisted;
- two tabs/devices can race with stale database or chat revisions;
- a lost HTTP response can make a successful save look like a failure;
- a late lazy-hydration response can overwrite a deleted, rerolled, or replaced chat;
- legacy plugin APIs can mistake a lazy placeholder for a real empty chat and write it back;
- browser storage APIs can stall during startup on some mobile browsers.

This PR treats those as one protocol boundary rather than independent optimizations.

## What changed

### Validated startup cache

- Adds ETag support and an encoded stripped-database cache on the server.
- Revalidates cached startup state with an authenticated conditional request before using it.
- Stores raw and decoded startup data in CacheStorage/IndexedDB with bounded patch journals.
- Falls back to an unconditional server read when a `304` is received but the local body is missing or invalid.
- Adds timeouts and best-effort failure handling so unavailable or stalled browser storage cannot block startup indefinitely.
- Invalidates the cache after database replacement/import/restore operations.

### Lazy chat synchronization

- Stores full chats server-side while `database.bin` contains canonical metadata stubs.
- Adds JSON Patch chat deltas with SHA-256 revisions and compare-and-swap preconditions.
- Uses a full save only when a delta is not worthwhile or the server does not support it; full saves still retain revision preconditions.
- Confirms the server snapshot after a lost response so a committed save is not retried forever.
- Fetches an authoritative revision before updating an existing chat whose local revision is unknown.
- Uses create-only writes for genuinely new chats and rejects unconditional overwrites.
- Bounds retained client snapshots by count and byte size.

### Server durability and serialization

- Adds a durable chat write-ahead journal before acknowledging full or delta saves.
- Replays acknowledged journal records after restart and retires them after the matching database metadata is durable.
- Serializes database reads, writes, patches, chat GET/POST operations, debounced persistence, and database removal through the storage queue.
- Makes cold-start chat-store initialization single-flight and generation-safe.
- Adds canonical stripped-database validation, duplicate-ID checks, chat-shape validation, and prototype-pollution guards.
- Cancels pending persistence and clears related cache/journal state when `database.bin` is explicitly removed.

### Client reconciliation and plugin safety

- Rolls back patcher baselines when the server does not accept a prepared patch.
- Uses three-way reconciliation (previous server baseline, current local state, latest server state) on database conflicts.
- Merges character/chat arrays by stable identity, preserves independent changes, and refuses to silently resolve a remote deletion against a tracked local edit.
- Prevents deterministic `409` loops from hammering the server while retaining dirty state for a later retry.
- Wakes paused saves when the browser becomes visible/online and retains a low-rate recovery retry for prolonged outages.
- Throttles streaming checkpoints while keeping the active chat dirty for visibility/pagehide flushes.
- Validates lazy hydration by character/chat identity before and after yielding.
- Hydrates V3 plugin getter targets before returning them, rejects placeholder/stub writes, and explicitly marks inactive plugin-mutated chats dirty.

## Benefits

- Unchanged reloads transfer only a conditional request/`304` instead of the complete database.
- A representative 247,373-byte chat append produced a 978-byte delta in two synthetic runs (about **99.60% less request data**).
- Large chat histories no longer multiply routine metadata-transfer costs.
- Stale clients fail safely instead of silently overwriting newer chat or database state.
- An acknowledged chat update survives the five-second persistence debounce and a process restart.
- Plugins no longer receive placeholders that look like valid empty chats.
- Mobile startup is less dependent on large decoding work and is protected against stalled CacheStorage/IndexedDB calls.

## Tradeoffs and known limitations

- This is a large, coupled change (21 files and roughly 5k added lines), so protocol review should cover the server and client together.
- The first uncached startup and first access to an uncached chat still require a server round trip.
- The startup cache stores a stripped database and decoded state in same-origin browser storage. That can include API settings, credentials, and plugin storage; it improves reload performance but increases at-rest browser persistence and should be considered in the threat model for shared devices or same-origin script compromise.
- V3 plugin getters that request a whole database or character now hydrate every requested placeholder before returning. This preserves the previous full-data contract but can cause a one-time network and memory spike for very large histories.
- Delta synchronization reduces network bytes, but preparing a save still encodes/normalizes/compares the chat, so client CPU cost remains approximately proportional to chat size.
- The durable server journal adds a synchronous local database write before each successful chat acknowledgement. This is the durability/throughput tradeoff.
- A newly created chat that is deleted before its first metadata stub is ever committed can leave an awaiting-metadata journal record until later cleanup; it does not reappear in `database.bin`, but it can occupy a small amount of server storage.
- Visibility/pagehide handling is best-effort. A hard browser-process kill at the exact moment a save is already in flight cannot be guaranteed without a persistent browser outbox or Service Worker background-sync design.
- Positional arrays without stable IDs use local-wins behavior when both sides change the same array concurrently.
- Backup import/export, save-folder import, and some update/shutdown flush boundaries are not fully moved into the new storage transaction model and should be reviewed in a follow-up.

## Validation

- `vitest run --testTimeout=15000`: **67 files passed; 991 tests passed; 3 skipped**.
- Focused cache/chat/conflict/plugin/server suite: **182 tests passed**.
- `svelte-check --tsconfig ./tsconfig.json`: **0 errors**; 4 pre-existing accessibility warnings in `DefaultChatScreen.svelte`.
- `vite build --sourcemap`: passed.
- `node --check` passed for `server.cjs`, `chatDelta.cjs`, and `chatWriteJournal.cjs`.
- `git diff --check`: passed (Windows line-ending notices only).

## Review focus

The most important review areas are:

1. server journal retirement and crash recovery;
2. chat/database compare-and-swap semantics;
3. three-way conflict reconciliation and remote deletion behavior;
4. plugin compatibility versus full-history hydration cost;
5. whether the startup-cache security/performance tradeoff should be configurable.
