### PR TITLE
feat: add Parallel Search MCP preset

### DIFF
--- a/src/ts/process/mcp/mcp.ts
+++ b/src/ts/process/mcp/mcp.ts
@@ -8,6 +8,7 @@ import type { MCPClientLike } from "./internalmcp";
 import { sleep } from "src/ts/util";
 import { registeredCustomPluginMCPs } from "./pluginmcp";
 import { makeEncodedStorageKey, readPersistentJson, writePersistentJson } from "src/ts/storage/persistentKv";
+import { getMcpModulePresets } from "./presets";
 
 export type MCPToolWithURL = MCPTool & {
     mcpURL: string;
@@ -185,19 +186,7 @@ export async function callTool(methodName:string, args:any) {
 }
 
 export async function importMCPModule(){
-    const x = await alertInput('Please enter the URL of the MCP module to import:', [
-        ['internal:aiaccess', 'LLM Call Client (internal:aiaccess)'],
-        ['internal:risuai', 'Risu Access Client (internal:risuai)'],
-        ['internal:fs', 'File System Client (internal:fs)'],
-        ['internal:googlesearch', 'Google Search Client (internal:googlesearch)'],
-        ['internal:dice', 'Dice Tool Client (internal:dice)'],
-        ['internal:graphmem', 'Graph Memory Client (internal:graphmem)'],
-        ['https://mcp.paypal.com/sse', 'PayPal MCP (https://mcp.paypal.com/sse)'],
-        ['https://mcp.linear.app/sse', 'Linear MCP (https://mcp.linear.app/sse)'],
-        ['https://rag-mcp-2.whatsmcp.workers.dev/sse', 'OneContext MCP (https://rag-mcp-2.whatsmcp.workers.dev/sse)'],
-        ['https://browser.mcp.cloudflare.com/sse', 'Cloudflare Browser MCP (https://browser.mcp.cloudflare.com/sse)'],
-        ['https://mcp.deepwiki.com/mcp', 'DeepWiki MCP (https://mcp.deepwiki.com/mcp)'],
-    ])
+    const x = await alertInput('Please enter the URL of the MCP module to import:', getMcpModulePresets())
 
     if(
         !x.startsWith('http://localhost') &&

--- a/src/ts/process/mcp/presets.test.ts
+++ b/src/ts/process/mcp/presets.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+import { getMcpModulePresets } from './presets'
+
+const incumbentPresets: [string, string][] = [
+    ['internal:aiaccess', 'LLM Call Client (internal:aiaccess)'],
+    ['internal:risuai', 'Risu Access Client (internal:risuai)'],
+    ['internal:fs', 'File System Client (internal:fs)'],
+    ['internal:googlesearch', 'Google Search Client (internal:googlesearch)'],
+    ['internal:dice', 'Dice Tool Client (internal:dice)'],
+    ['internal:graphmem', 'Graph Memory Client (internal:graphmem)'],
+    ['https://mcp.paypal.com/sse', 'PayPal MCP (https://mcp.paypal.com/sse)'],
+    ['https://mcp.linear.app/sse', 'Linear MCP (https://mcp.linear.app/sse)'],
+    ['https://rag-mcp-2.whatsmcp.workers.dev/sse', 'OneContext MCP (https://rag-mcp-2.whatsmcp.workers.dev/sse)'],
+    ['https://browser.mcp.cloudflare.com/sse', 'Cloudflare Browser MCP (https://browser.mcp.cloudflare.com/sse)'],
+    ['https://mcp.deepwiki.com/mcp', 'DeepWiki MCP (https://mcp.deepwiki.com/mcp)'],
+]
+
+describe('MCP module presets', () => {
+    test('preserves incumbent presets and appends Parallel Search', () => {
+        const presets = getMcpModulePresets()
+
+        expect(presets.slice(0, incumbentPresets.length)).toEqual(incumbentPresets)
+        expect(presets.at(-1)).toEqual([
+            'https://search.parallel.ai/mcp',
+            'Parallel Search MCP (https://search.parallel.ai/mcp)',
+        ])
+        expect(presets.filter(([value]) => value === 'https://search.parallel.ai/mcp')).toHaveLength(1)
+    })
+
+    test('returns fresh tuples for each import prompt', () => {
+        const first = getMcpModulePresets()
+        first[0][0] = 'mutated'
+
+        expect(getMcpModulePresets()[0]).toEqual(incumbentPresets[0])
+    })
+})

--- a/src/ts/process/mcp/presets.ts
+++ b/src/ts/process/mcp/presets.ts
@@ -1,0 +1,18 @@
+const MCP_MODULE_PRESETS = [
+    ['internal:aiaccess', 'LLM Call Client (internal:aiaccess)'],
+    ['internal:risuai', 'Risu Access Client (internal:risuai)'],
+    ['internal:fs', 'File System Client (internal:fs)'],
+    ['internal:googlesearch', 'Google Search Client (internal:googlesearch)'],
+    ['internal:dice', 'Dice Tool Client (internal:dice)'],
+    ['internal:graphmem', 'Graph Memory Client (internal:graphmem)'],
+    ['https://mcp.paypal.com/sse', 'PayPal MCP (https://mcp.paypal.com/sse)'],
+    ['https://mcp.linear.app/sse', 'Linear MCP (https://mcp.linear.app/sse)'],
+    ['https://rag-mcp-2.whatsmcp.workers.dev/sse', 'OneContext MCP (https://rag-mcp-2.whatsmcp.workers.dev/sse)'],
+    ['https://browser.mcp.cloudflare.com/sse', 'Cloudflare Browser MCP (https://browser.mcp.cloudflare.com/sse)'],
+    ['https://mcp.deepwiki.com/mcp', 'DeepWiki MCP (https://mcp.deepwiki.com/mcp)'],
+    ['https://search.parallel.ai/mcp', 'Parallel Search MCP (https://search.parallel.ai/mcp)'],
+] as const
+
+export function getMcpModulePresets(): [string, string][] {
+    return MCP_MODULE_PRESETS.map(([value, label]) => [value, label])
+}


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [ ] If your PR is highly AI generated[^2], check the following:
    - [ ] Have you understood what the code does?
    - [ ] Have you cleaned up any unnecessary or redundant code?
    - [ ] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds Parallel Search as an opt-in choice in PocketRisu's existing MCP import prompt.

## Related Issues

None.

## Changes

- Moves the existing MCP preset tuples into a small side-effect-free module.
- Appends `https://search.parallel.ai/mcp` without changing incumbent presets or their order.
- Adds focused tests for the complete preset list, endpoint uniqueness, and fresh-copy behavior.

## Impact

Users can select the public Parallel Search MCP endpoint without entering the URL manually. The built-in Google Search client, existing presets, custom URL support, handshake flow, and defaults are unchanged.

## Additional Notes

Validated with the focused MCP preset tests, Svelte and TypeScript checks, the 1,042-test client suite, diff hygiene, and a credential-free MCP initialize request. Live model-backed tool selection was not part of this preset-only change.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.