### PR TITLE
fix: prevent asset loss from client-side boot cleanup

### DIFF
--- a/server/node/cleanupScan.cjs
+++ b/server/node/cleanupScan.cjs
@@ -1,0 +1,75 @@
+'use strict'
+
+const DEFAULT_SCAN_TTL_MS = 10 * 60 * 1000;
+
+class CleanupScanError extends Error {
+    constructor(reason) {
+        super('Cleanup scan is no longer valid');
+        this.name = 'CleanupScanError';
+        this.code = 'CLEANUP_SCAN_INVALID';
+        this.reason = reason;
+    }
+}
+
+function createCleanupScanStore(options) {
+    options = options || {};
+    const now = options.now || Date.now;
+    const randomUUID = options.randomUUID;
+    const ttlMs = options.ttlMs || DEFAULT_SCAN_TTL_MS;
+    let pending = null;
+
+    function issue(sessionId, candidateKeys) {
+        const issuedAt = now();
+        pending = {
+            scanId: randomUUID(),
+            sessionId,
+            expiresAt: issuedAt + ttlMs,
+            candidateKeys: new Set(candidateKeys),
+        };
+        return { scanId: pending.scanId, expiresAt: pending.expiresAt };
+    }
+
+    function consume(scanId, sessionId) {
+        const scan = pending;
+        if (!scan || scan.scanId !== scanId) {
+            throw new CleanupScanError('missing-or-replaced');
+        }
+        if (scan.expiresAt <= now()) {
+            pending = null;
+            throw new CleanupScanError('expired');
+        }
+        if (scan.sessionId !== sessionId) {
+            throw new CleanupScanError('session-mismatch');
+        }
+        // One-shot even if revalidation or deletion later fails.
+        pending = null;
+        return scan;
+    }
+
+    return { issue, consume };
+}
+
+function intersectCandidates(originalKeys, currentEntries) {
+    const currentByKey = new Map(currentEntries.map((entry) => [entry.key, entry]));
+    const eligible = [];
+    for (const key of originalKeys) {
+        const entry = currentByKey.get(key);
+        if (entry) eligible.push(entry);
+    }
+    return eligible;
+}
+
+function deleteKeysAtomically(db, deleteKey, keys) {
+    const run = db.transaction((items) => {
+        for (const key of items) deleteKey(key);
+    });
+    run(keys);
+}
+
+module.exports = {
+    CleanupScanError,
+    DEFAULT_SCAN_TTL_MS,
+    createCleanupScanStore,
+    intersectCandidates,
+    deleteKeysAtomically,
+};

--- a/server/node/orphanCleanup.cjs
+++ b/server/node/orphanCleanup.cjs
@@ -1,0 +1,102 @@
+'use strict'
+
+// 7-day grace for assets and remotes.
+const GRACE_MS = 1000 * 60 * 60 * 24 * 7;
+
+/**
+ * Finds assets and remotes eligible under the current cleanup rules.
+ *
+ * Uses the server-validated current DB reference set (buildUncleanableSet from
+ * server.cjs). This view avoids granting deletion authority to a single
+ * client reference set, but it is not a claim about every historical or
+ * concurrently changing DB generation.
+ *
+ * Rules:
+ *  - assets/*: orphan if basename not in the uncleanable set and its existing
+ *    updated_at timestamp is older than the grace period. Missing/invalid
+ *    timestamps are preserved conservatively.
+ *  - remotes/*: orphan if the character no longer exists AND the 7-day grace
+ *    (based on the .meta lastUsed timestamp) has elapsed. No .meta → grace
+ *    not started → skip (will be picked up on a later pass).
+ *  - .meta entries are always skipped.
+ *
+ * Returns a list of { key, size, prefix, reason } entries. Does NOT delete —
+ * the caller (the /api/cleanup/orphan-assets endpoint) decides whether to
+ * dry-run (return the list) or confirm (kvDel each key).
+ */
+function findOrphans(dbObj, assetEntries, remoteEntries, uncleanable, now) {
+    if (now === undefined) now = Date.now();
+    const characterIds = new Set(
+        Array.isArray(dbObj && dbObj.characters)
+            ? dbObj.characters.map(function (c) { return c && c.chaId; }).filter(Boolean)
+            : []
+    );
+    const orphans = [];
+
+    for (let i = 0; i < assetEntries.length; i++) {
+        var it = assetEntries[i];
+        if (!it || !it.key || it.key.endsWith('.meta')) continue;
+        var bn = basename(it.key);
+        if (typeof it.updatedAt !== 'number' || !Number.isFinite(it.updatedAt)
+            || now - it.updatedAt <= GRACE_MS) continue;
+        if (!uncleanable.has(bn)) {
+            orphans.push({ key: it.key, size: it.size || 0, prefix: 'assets', reason: 'unreferenced' });
+        }
+    }
+
+    for (let i = 0; i < remoteEntries.length; i++) {
+        var it = remoteEntries[i];
+        if (!it || !it.key || it.key.endsWith('.meta')) continue;
+        var bn = basename(it.key);
+        var name = bn.endsWith('.local.bin') ? bn.slice(0, -10) : bn;
+        if (characterIds.has(name)) continue;
+        var meta = it.meta ? parseMeta(it.meta) : null;
+        if (!meta) continue; // no meta or corrupt meta → grace not established, skip
+        var lastUsed = meta.lastUsed || 0;
+        if (now - lastUsed > GRACE_MS) {
+            orphans.push({ key: it.key, size: it.size || 0, prefix: 'remotes', reason: 'stale' });
+        }
+    }
+
+    return orphans;
+}
+
+function basename(s) {
+    return String(s).replace(/\\/g, '/').split('/').pop();
+}
+
+function parseMeta(buf) {
+    try {
+        if (Buffer.isBuffer(buf)) return JSON.parse(buf.toString('utf-8'));
+        if (buf instanceof Uint8Array) return JSON.parse(new TextDecoder().decode(buf));
+        return JSON.parse(String(buf));
+    } catch {
+        return null;
+    }
+}
+
+// Plugin-owned settings may store asset paths in arbitrary nested structures,
+// and new core fields can appear without being added to the manual walker.
+// Preserve every DB string that is an assets/* path as a conservative safety
+// net. Only basenames are needed by the existing cleanup logic.
+function collectAssetBasenames(value, target, seen) {
+    if (!target) target = new Set();
+    if (!seen) seen = new WeakSet();
+    if (typeof value === 'string') {
+        if (value.startsWith('assets/')) {
+            var bn = basename(value);
+            if (bn) target.add(bn);
+        }
+        return target;
+    }
+    if (!value || typeof value !== 'object' || seen.has(value)) return target;
+    seen.add(value);
+    if (Array.isArray(value)) {
+        for (var i = 0; i < value.length; i++) collectAssetBasenames(value[i], target, seen);
+    } else {
+        for (var key of Object.keys(value)) collectAssetBasenames(value[key], target, seen);
+    }
+    return target;
+}
+
+module.exports = { findOrphans, collectAssetBasenames, GRACE_MS };

--- a/server/node/orphanCleanup.test.ts
+++ b/server/node/orphanCleanup.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import pkg from './orphanCleanup.cjs'
+
+const { findOrphans, collectAssetBasenames, GRACE_MS } = pkg as {
+    findOrphans: (
+        dbObj: any,
+        assetEntries: { key: string; size: number; updatedAt?: number; meta?: Uint8Array }[],
+        remoteEntries: { key: string; size: number; meta?: Uint8Array }[],
+        uncleanable: Set<string>,
+        now?: number,
+    ) => { key: string; size: number; prefix: string; reason: string }[]
+    GRACE_MS: number
+    collectAssetBasenames: (value: unknown, target?: Set<string>) => Set<string>
+}
+
+const NOW = 1_000_000_000_000
+const OLD = NOW - GRACE_MS - 1
+const enc = (obj: object) => new TextEncoder().encode(JSON.stringify(obj))
+
+describe('server-validated current-view candidate detection', () => {
+    it('flags assets whose basename is not in the uncleanable set', () => {
+        const db = { characters: [] }
+        const assets = [{ key: 'assets/abc.png', size: 100, updatedAt: OLD }, { key: 'assets/def.png', size: 200, updatedAt: OLD }]
+        const uncleanable = new Set(['abc.png'])
+        const result = findOrphans(db, assets, [], uncleanable, NOW)
+        expect(result).toHaveLength(1)
+        expect(result[0].key).toBe('assets/def.png')
+        expect(result[0].prefix).toBe('assets')
+        expect(result[0].reason).toBe('unreferenced')
+    })
+
+    it('does not flag assets that ARE in the uncleanable set', () => {
+        const db = { characters: [] }
+        const assets = [{ key: 'assets/keep.png', size: 50, updatedAt: OLD }]
+        const uncleanable = new Set(['keep.png'])
+        expect(findOrphans(db, assets, [], uncleanable, NOW)).toHaveLength(0)
+    })
+
+    it('skips .meta entries', () => {
+        const db = { characters: [] }
+        const assets = [{ key: 'assets/orphan.png.meta', size: 10 }]
+        const uncleanable = new Set<string>()
+        expect(findOrphans(db, assets, [], uncleanable, NOW)).toHaveLength(0)
+    })
+
+    it('does not flag remotes whose character still exists', () => {
+        const db = { characters: [{ chaId: 'ghost' }] }
+        const remotes = [{ key: 'remotes/ghost.local.bin', size: 500 }]
+        const uncleanable = new Set<string>()
+        expect(findOrphans(db, [], remotes, uncleanable, NOW)).toHaveLength(0)
+    })
+
+    it('does not flag remotes within the 7-day grace period', () => {
+        const db = { characters: [] }
+        const recent = NOW - GRACE_MS + 1000
+        const remotes = [{ key: 'remotes/ghost.local.bin', size: 500, meta: enc({ lastUsed: recent }) }]
+        const uncleanable = new Set<string>()
+        expect(findOrphans(db, [], remotes, uncleanable, NOW)).toHaveLength(0)
+    })
+
+    it('flags remotes past the 7-day grace period', () => {
+        const db = { characters: [] }
+        const old = NOW - GRACE_MS - 1000
+        const remotes = [{ key: 'remotes/ghost.local.bin', size: 500, meta: enc({ lastUsed: old }) }]
+        const uncleanable = new Set<string>()
+        const result = findOrphans(db, [], remotes, uncleanable, NOW)
+        expect(result).toHaveLength(1)
+        expect(result[0].prefix).toBe('remotes')
+        expect(result[0].reason).toBe('stale')
+    })
+
+    it('skips remotes with no .meta (grace not started)', () => {
+        const db = { characters: [] }
+        const remotes = [{ key: 'remotes/ghost.local.bin', size: 500 }]
+        const uncleanable = new Set<string>()
+        expect(findOrphans(db, [], remotes, uncleanable, NOW)).toHaveLength(0)
+    })
+
+    it('handles corrupt .meta gracefully (treats as no meta)', () => {
+        const db = { characters: [] }
+        const badMeta = new Uint8Array([0, 1, 2, 3])
+        const remotes = [{ key: 'remotes/ghost.local.bin', size: 500, meta: badMeta }]
+        const uncleanable = new Set<string>()
+        expect(findOrphans(db, [], remotes, uncleanable, NOW)).toHaveLength(0)
+    })
+
+})
+
+describe('asset cleanup safety protections', () => {
+    it('preserves assets created or overwritten within the 7-day grace period', () => {
+        const assets = [
+            { key: 'assets/recent.png', size: 10, updatedAt: NOW - GRACE_MS + 1 },
+            { key: 'assets/old.png', size: 20, updatedAt: OLD },
+            { key: 'assets/unknown.png', size: 30 },
+        ]
+        const result = findOrphans({ characters: [] }, assets, [], new Set(), NOW)
+        expect(result.map(entry => entry.key)).toEqual(['assets/old.png'])
+    })
+
+    it('collects GPT-SoVITS reference audio asset paths', () => {
+        const db = {
+            characters: [{
+                gptSoVitsConfig: { ref_audio_data: { assetId: 'assets/reference.wav' } },
+            }],
+        }
+        expect([...collectAssetBasenames(db)]).toEqual(['reference.wav'])
+    })
+
+    it('collects arbitrary nested plugin asset paths', () => {
+        const db = {
+            pluginData: {
+                arbitrary: [{ futureField: 'assets/plugin-image.webp' }],
+                ignored: 'https://example.invalid/assets/not-local.png',
+            },
+        }
+        expect([...collectAssetBasenames(db)]).toEqual(['plugin-image.webp'])
+    })
+})

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -3344,6 +3344,7 @@ app.get('/api/read', async (req, res, next) => {
 });
 
 app.get('/api/remove', async (req, res, next) => {
+    res.setHeader('Cache-Control', 'no-store');
     if(!await checkAuth(req, res)){
         return;
     }
@@ -3358,6 +3359,17 @@ app.get('/api/remove', async (req, res, next) => {
     }
     try {
         const key = Buffer.from(filePath, 'hex').toString('utf-8');
+        // Older clients ran cleanChunks() by listing assets/remotes and then
+        // deleting each key through this generic endpoint. A 409 (rather than
+        // a successful no-op) stops that legacy loop on its first request.
+        // Asset cleanup is only allowed through the server-validated,
+        // confirmable orphan-cleanup endpoint below.
+        if (key.startsWith('assets/') || key.startsWith('remotes/')) {
+            return res.status(409).json({
+                error: 'DIRECT_ASSET_REMOVE_DISABLED',
+                code: 'DIRECT_ASSET_REMOVE_DISABLED',
+            });
+        }
         if (key.startsWith('inlay/')) {
             const id = key.slice('inlay/'.length)
             await deleteInlayFile(id)

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -1449,6 +1449,16 @@ async function checkDiskSpace(requiredBytes) {
 // not kick a PC mid-session); ownership moves on the first WRITE from a
 // freshly-booted session, and only stale sessions get 423.
 const { createSessionLock } = require('./session-lock.cjs');
+const { findOrphans, collectAssetBasenames } = require('./orphanCleanup.cjs');
+const {
+    CleanupScanError,
+    createCleanupScanStore,
+    intersectCandidates,
+    deleteKeysAtomically,
+} = require('./cleanupScan.cjs');
+const cleanupScanStore = createCleanupScanStore({
+    randomUUID: () => nodeCrypto.randomUUID(),
+});
 const sessionLock = createSessionLock();
 
 function checkActiveSession(req, res) {
@@ -3388,6 +3398,107 @@ app.get('/api/remove', async (req, res, next) => {
     }
 });
 
+// ── Server-side orphan cleanup (replaces client-side cleanChunks deletion) ────
+// Compute candidates from the server's current DB view instead of granting a
+// single client's reference set direct deletion authority. Dry-run-by-default
+// and the active-session requirement reduce risk; they do not guarantee that
+// this view represents every historical or concurrent DB generation.
+// Both phases run in the storage queue. A dry-run pins its candidate keys to a
+// short-lived server-side scan; confirm deletes only keys that were in that scan
+// and are still eligible now.
+function currentCleanupCandidates() {
+    const dbObj = dbCache[DB_HEX_KEY];
+    if (!dbObj) {
+        const error = new Error('Database not loaded');
+        error.status = 503;
+        throw error;
+    }
+    const uncleanable = buildUncleanableSet(dbObj);
+    // Keep kvListWithSizes() stable for existing callers. Cleanup alone
+    // enriches its rows with the already-present updated_at column.
+    const assetEntries = kvListWithSizes('assets/').map((entry) => ({
+        ...entry, updatedAt: kvGetUpdatedAt(entry.key),
+    }));
+    const remoteEntries = kvListWithSizes('remotes/').map((entry) => ({
+        ...entry, meta: kvGet(entry.key + '.meta'),
+    }));
+    return findOrphans(dbObj, assetEntries, remoteEntries, uncleanable);
+}
+
+app.post('/api/cleanup/orphan-assets', async (req, res, next) => {
+    res.setHeader('Cache-Control', 'no-store');
+    if(!await checkAuth(req, res)) return;
+    if (!checkActiveSession(req, res)) return;
+
+    const sessionId = typeof req.headers['x-session-id'] === 'string'
+        ? req.headers['x-session-id']
+        : '';
+    const confirm = req.query.confirm === 'true';
+
+    try {
+        const result = await queueStorageOperation(() => {
+            if (!confirm) {
+                const candidates = currentCleanupCandidates();
+                const totalSize = candidates.reduce((sum, entry) => sum + entry.size, 0);
+                const scan = cleanupScanStore.issue(
+                    sessionId,
+                    candidates.map((entry) => entry.key),
+                );
+                return {
+                    confirm: false,
+                    scanId: scan.scanId,
+                    expiresAt: scan.expiresAt,
+                    count: candidates.length,
+                    totalSize,
+                    entries: candidates.map((entry) => ({
+                        key: entry.key,
+                        size: entry.size,
+                        prefix: entry.prefix,
+                        reason: entry.reason,
+                    })),
+                };
+            }
+
+            const scanId = req.body && req.body.scanId;
+            if (typeof scanId !== 'string' || !scanId) {
+                throw new CleanupScanError('missing-scan-id');
+            }
+            const scan = cleanupScanStore.consume(scanId, sessionId);
+            const current = currentCleanupCandidates();
+            const eligible = intersectCandidates(scan.candidateKeys, current);
+            const requestedCount = scan.candidateKeys.size;
+            const totalSize = eligible.reduce((sum, entry) => sum + entry.size, 0);
+
+            deleteKeysAtomically(
+                sqliteDb,
+                (key) => kvDel(key),
+                eligible.map((entry) => entry.key),
+            );
+            console.log(`[cleanup] reclaimed ${eligible.length}/${requestedCount} orphan(s), ${totalSize} bytes`);
+            return {
+                confirm: true,
+                count: eligible.length,
+                totalSize,
+                requestedCount,
+                skippedCount: requestedCount - eligible.length,
+            };
+        });
+        res.json(result);
+    } catch (error) {
+        if (error instanceof CleanupScanError) {
+            return res.status(409).json({
+                error: error.code,
+                code: error.code,
+                reason: error.reason,
+            });
+        }
+        if (error && error.status === 503) {
+            return res.status(503).json({ error: error.message });
+        }
+        next(error);
+    }
+});
+
 app.get('/api/list', async (req, res, next) => {
     if(!await checkAuth(req, res)){
         return;
@@ -5122,6 +5233,10 @@ function buildUncleanableSet(dbObj, { includeModuleAssets = true } = {}) {
             if (Array.isArray(cha.emotionImages)) for (const em of cha.emotionImages) add(em?.[1]);
             if (Array.isArray(cha.additionalAssets)) for (const em of cha.additionalAssets) add(em?.[1]);
             if (cha.vits?.files) for (const k of Object.keys(cha.vits.files)) add(cha.vits.files[k]);
+            // The UI stores saveAsset() output here and GPT-SoVITS TTS passes
+            // this supported field to loadAsset(). Protect it preventively;
+            // incident evidence does not implicate GPT-SoVITS.
+            add(cha.gptSoVitsConfig?.ref_audio_data?.assetId);
             if (Array.isArray(cha.ccAssets)) for (const a of cha.ccAssets) add(a?.uri);
         }
     }
@@ -5144,6 +5259,9 @@ function buildUncleanableSet(dbObj, { includeModuleAssets = true } = {}) {
             if (item && typeof item === 'object' && 'imgFile' in item) add(item.imgFile);
         }
     }
+    // Conservative safety net for real fields omitted by the manual walker,
+    // plugin-defined nested storage, and future DB fields.
+    if (includeModuleAssets) collectAssetBasenames(dbObj, set);
     return set;
 }
 

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -2059,6 +2059,22 @@ export const languageEnglish = {
     storageWalCleanupNoop: "WAL is already clean.",
     storageWalCleanupFailed: "WAL cleanup failed",
 
+    orphanCleanup: "Reclaim orphan assets",
+    orphanCleanupHeader: (count: number, size: number) =>
+        `${count} orphan(s) · ${(size / 1024 / 1024).toFixed(1)} MB`,
+    orphanCleanupWhat: "Orphan assets are stored files no longer referenced by any character, module, or persona. They accumulate as you delete and re-create content. Reclaiming them frees disk space.",
+    orphanCleanup_btn: "Reclaim orphans",
+    orphanCleanupScanning: "Scanning for orphans…",
+    orphanCleanupConfirm: (count: number, size: number) =>
+        `Delete ${count} orphan asset(s) (${(size / 1024 / 1024).toFixed(1)} MB)? This cannot be undone.`,
+    orphanCleanupDone: (count: number, size: number) =>
+        `Reclaimed ${count} orphan(s), ${(size / 1024 / 1024).toFixed(1)} MB.`,
+    orphanCleanupDoneWithSkipped: (count: number, size: number, skipped: number) =>
+        `Reclaimed ${count} orphan(s), ${(size / 1024 / 1024).toFixed(1)} MB. ${skipped} item(s) were excluded because their state changed.`,
+    orphanCleanupRescan: "The cleanup scan expired or was replaced. Scan again before deleting.",
+    orphanCleanupNone: "No orphan assets found.",
+    orphanCleanupFailed: "Orphan cleanup failed",
+
     storageBackups: "Backups",
     storageBackupsManage: "Manage backups",
     storageBackupsAuto: "Snapshot (DB only)",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -2248,6 +2248,22 @@ export const languageKorean = {
   storageWalCleanupNoop: "WAL은 이미 깨끗합니다.",
   storageWalCleanupFailed: "WAL 정리 실패",
 
+  orphanCleanup: "고아 에셋 회수",
+  orphanCleanupHeader: (count: number, size: number) =>
+    `${count}개 고아 · ${(size / 1024 / 1024).toFixed(1)} MB`,
+  orphanCleanupWhat: "고아 에셋은 더 이상 어떤 캐릭터·모듈·페르소나에서도 참조하지 않는 저장 파일입니다. 콘텐츠를 삭제하고 다시 만들면서 누적됩니다. 회수하면 디스크 공간이 확보됩니다.",
+  orphanCleanup_btn: "고아 회수",
+  orphanCleanupScanning: "고아 스캔 중…",
+  orphanCleanupConfirm: (count: number, size: number) =>
+    `${count}개 고아 에셋(${(size / 1024 / 1024).toFixed(1)} MB)을 삭제할까요? 되돌릴 수 없습니다.`,
+  orphanCleanupDone: (count: number, size: number) =>
+    `${count}개 고아 회수, ${(size / 1024 / 1024).toFixed(1)} MB.`,
+  orphanCleanupDoneWithSkipped: (count: number, size: number, skipped: number) =>
+    `${count}개 고아 회수, ${(size / 1024 / 1024).toFixed(1)} MB. ${skipped}개는 상태가 변경되어 제외했습니다.`,
+  orphanCleanupRescan: "정리 스캔이 만료되었거나 교체되었습니다. 삭제 전에 다시 스캔해 주세요.",
+  orphanCleanupNone: "고아 에셋이 없습니다.",
+  orphanCleanupFailed: "고아 정리 실패",
+
   storageBackups: "백업",
   storageBackupsManage: "백업 관리",
   storageBackupsAuto: "스냅샷 (DB만)",

--- a/src/lib/Setting/Pages/SystemDashboard.svelte
+++ b/src/lib/Setting/Pages/SystemDashboard.svelte
@@ -17,6 +17,7 @@
         BlocksIcon,
         ShieldCheckIcon,
         SaveIcon,
+        TrashIcon,
     } from '@lucide/svelte'
     import { alertConfirm, alertMd, notifyError, notifySuccess } from 'src/ts/alert'
     import { forageStorage } from 'src/ts/globalApi.svelte'
@@ -86,6 +87,8 @@
     let optimizeMessage = $state('')
 
     let walCleanupOpen = $state(false)
+
+    let orphanCleanupOpen = $state(false)
 
     // Default off = show only RisuAI internal breakdown (smaller scope, more
     // useful at-a-glance). Toggle on to expand the bar to disk-total scale
@@ -222,6 +225,42 @@
             notifyError(language.storageOptimizeFailed + ': ' + (err instanceof Error ? err.message : String(err)))
         } finally {
             optimizeOpen = false
+        }
+    }
+
+    async function runOrphanCleanup() {
+        orphanCleanupOpen = true
+        try {
+            const dryRun = await forageStorage.cleanupOrphanAssets(false)
+            if (dryRun.count === 0) {
+                notifySuccess(language.orphanCleanupNone)
+                return
+            }
+            const ok = await alertConfirm(language.orphanCleanupConfirm(dryRun.count, dryRun.totalSize))
+            if (!ok) return
+            if (!dryRun.scanId) {
+                notifyError(language.orphanCleanupRescan)
+                return
+            }
+            const result = await forageStorage.cleanupOrphanAssets(true, dryRun.scanId)
+            if ((result.skippedCount ?? 0) > 0) {
+                notifySuccess(language.orphanCleanupDoneWithSkipped(
+                    result.count,
+                    result.totalSize,
+                    result.skippedCount ?? 0,
+                ))
+            } else {
+                notifySuccess(language.orphanCleanupDone(result.count, result.totalSize))
+            }
+            await loadStats()
+        } catch (err) {
+            if ((err as { code?: string })?.code === 'CLEANUP_SCAN_INVALID') {
+                notifyError(language.orphanCleanupRescan)
+            } else {
+                notifyError(language.orphanCleanupFailed + ': ' + (err instanceof Error ? err.message : String(err)))
+            }
+        } finally {
+            orphanCleanupOpen = false
         }
     }
 
@@ -537,6 +576,28 @@
         </div>
     </div>
 
+    <!-- ②b Orphan asset cleanup ─────────────────────────────────────────── -->
+    <div class="border border-darkborderc bg-darkbg/40 rounded-md p-4 mb-4">
+        <div class="flex items-baseline justify-between gap-2 mb-3 flex-wrap">
+            <div class="flex items-center gap-2 text-textcolor">
+                <TrashIcon size={16} />
+                <span class="font-medium">{language.orphanCleanup}</span>
+            </div>
+            <span class="text-textcolor2 text-sm tabular-nums">
+                {stats?.orphan?.available
+                    ? language.orphanCleanupHeader(stats.orphan.count, stats.orphan.totalSize)
+                    : '—'}
+            </span>
+        </div>
+        <p class="text-textcolor2 text-sm leading-relaxed mb-3">{language.orphanCleanupWhat}</p>
+        <div class="flex justify-end">
+            <ShButton variant="outline" onclick={runOrphanCleanup} disabled={orphanCleanupOpen}>
+                <TrashIcon size={16} />
+                {language.orphanCleanup_btn}
+            </ShButton>
+        </div>
+    </div>
+
     <!-- ③ SQLite overhead cleanup ──────────────────────────────────────── -->
     <div class="border border-darkborderc bg-darkbg/40 rounded-md p-4 mb-4">
         <div class="flex items-baseline justify-between gap-2 mb-3 flex-wrap">
@@ -806,3 +867,4 @@
 
 <ShLoadingDialog open={optimizeOpen} message={optimizeMessage} tier="top" />
 <ShLoadingDialog open={walCleanupOpen} message={language.storageWalCleanuping} tier="top" />
+<ShLoadingDialog open={orphanCleanupOpen} message={language.orphanCleanupScanning} tier="top" />

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -25,14 +25,13 @@ import {
     saveDb,
     setPatchSyncBaseline,
     getDbBackups,
-    getUncleanables,
-    getBasename,
     checkCharOrder
 } from "./globalApi.svelte";
 import { registerModelDynamic } from "./model/modellist";
 import { initModelJobRecovery } from "./process/request/jobRecovery";
 import { convertStubsToPlaceholders } from "./storage/chatStorage";
 import { isChatStub, purgeUnsupportedGroupChats } from "./storage/database.svelte";
+
 
 /**
  * Loads the application data.
@@ -176,10 +175,6 @@ export async function loadData() {
             registerModelDynamic()
             saveDb()
             moduleUpdate()
-            // cleanChunks는 화면 진입 후 유휴 시간에 실행 (부트 블로킹 제거)
-            setTimeout(() => {
-                cleanChunks().catch(console.error)
-            }, 5_000)
             checkRisuUpdate()
             fetchPublicStats()
             // Server-side model-job recovery (jobRecovery.ts): slot journaled
@@ -503,59 +498,6 @@ async function checkNewFormat(): Promise<void> {
         }
     }
     void sweepOrphanDrafts(validDraftKeys);
-}
-
-/**
- * Purges chunks of data that are not needed.
- */
-async function cleanChunks() {
-    const db = getDatabase()
-    const uncleanable = new Set(getUncleanables(db))
-    const indexes = await forageStorage.keys()
-    const allKeys = new Set(indexes)
-    const characterIds = new Set<string>(
-        db.characters.map((v) => v.chaId)
-    )
-    for (const asset of indexes) {
-        if (asset.endsWith('.meta')) {
-            continue
-        }
-        else if (asset.startsWith('assets/')) {
-            const n = getBasename(asset)
-            if(!uncleanable.has(n)) {
-                await forageStorage.removeItem(asset)
-            }
-        }
-        else if (asset.startsWith('remotes/')) {
-            const name = getBasename(asset).slice(0, -10) //remove .local.bin
-            const exists = characterIds.has(name)
-            if(!exists){
-                let okayToDelete = false
-                try {
-                    const metaPath = asset + '.meta'
-                    const metaExists = allKeys.has(metaPath)
-                    if (metaExists) {
-                        const metaData: Uint8Array = await forageStorage.getItem(metaPath) as unknown as Uint8Array
-                        const metaJson = JSON.parse(new TextDecoder().decode(metaData))
-                        const lastUsed = metaJson.lastUsed as number
-                        if(Date.now() - lastUsed > 1000 * 60 * 60 * 24 * 7) { //not used for 7 days
-                            okayToDelete = true
-                        }
-                    }
-                    else{
-                        //write meta for next time
-                        const metaJson = {
-                            lastUsed: Date.now()
-                        }
-                        await forageStorage.setItem(metaPath, new TextEncoder().encode(JSON.stringify(metaJson)))
-                    }
-                } catch (error) {}
-                if (okayToDelete) {
-                    await forageStorage.removeItem(asset)
-                }
-            }
-        }
-    }
 }
 
 

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -20,6 +20,11 @@ export class AutoStorage{
         return await this.realStorage.removeItem(key)
     }
 
+    async cleanupOrphanAssets(confirm:boolean = false, scanId?:string){
+        await this.Init()
+        return this.realStorage.cleanupOrphanAssets(confirm, scanId)
+    }
+
     async checkAccountSync(){
         return false
     }

--- a/src/ts/storage/nodeStorage.ts
+++ b/src/ts/storage/nodeStorage.ts
@@ -36,6 +36,15 @@ export class ConflictError extends Error {
         this.currentEtag = currentEtag
     }
 }
+export class CleanupScanInvalidError extends Error {
+    code = 'CLEANUP_SCAN_INVALID'
+    reason: string
+    constructor(reason: string) {
+        super('Cleanup scan expired or was replaced')
+        this.name = 'CleanupScanInvalidError'
+        this.reason = reason
+    }
+}
 
 // Warning the server attaches to /api/patch responses when the most recent
 // debounced persist failed (Stage 1 visibility — see issues.md).
@@ -319,6 +328,36 @@ export class NodeStorage{
         const data = await da.json()
         if(data.error){
             throw data.error
+        }
+    }
+
+    async cleanupOrphanAssets(confirm:boolean = false, scanId?:string){
+        const url = '/api/cleanup/orphan-assets' + (confirm ? '?confirm=true' : '')
+        const init: RequestInit = { method: "POST" }
+        if (confirm) {
+            init.headers = { 'content-type': 'application/json' }
+            init.body = JSON.stringify({ scanId })
+        }
+        const response = await this.authFetch(url, init)
+        const data = await response.json().catch(() => ({}))
+        if(response.status < 200 || response.status >= 300){
+            if (response.status === 409 && data?.code === 'CLEANUP_SCAN_INVALID') {
+                throw new CleanupScanInvalidError(data.reason)
+            }
+            throw new Error(data?.error || 'cleanupOrphanAssets Error')
+        }
+        if(data.error){
+            throw new Error(data.error)
+        }
+        return data as {
+            confirm: boolean
+            count: number
+            totalSize: number
+            scanId?: string
+            expiresAt?: number
+            requestedCount?: number
+            skippedCount?: number
+            entries?: { key: string; size: number; prefix: string; reason: string }[]
         }
     }
 

--- a/test/compat/legacy-remove-guard.test.ts
+++ b/test/compat/legacy-remove-guard.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, describe, expect, test } from 'vitest'
+import { spawnServer, type ServerHandle } from './helpers/spawnServer.js'
+import { createClient } from './helpers/client.js'
+
+const servers: ServerHandle[] = []
+afterAll(async () => {
+  await Promise.allSettled(servers.map(server => server.cleanup()))
+})
+
+const hex = (value: string) => Buffer.from(value, 'utf-8').toString('hex')
+
+describe('legacy GET /api/remove guard', () => {
+  test('preserves assets/remotes and keeps other namespace deletion working', async () => {
+    const server = await spawnServer()
+    servers.push(server)
+    const client = await createClient(server.port, server.password)
+    const sessionId = 'legacy-remove-guard'
+
+    await client.fetch('/api/session', {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId },
+    })
+
+    const write = async (key: string) => {
+      const response = await client.fetch('/api/write', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/octet-stream',
+          'file-path': hex(key),
+          'x-session-id': sessionId,
+          'x-user-active': '1',
+        },
+        body: new Uint8Array([1, 2, 3]),
+      })
+      expect(response.ok).toBe(true)
+    }
+    const read = async (key: string) => {
+      const response = await client.fetch('/api/read', {
+        headers: { 'file-path': hex(key) },
+      })
+      return Buffer.from(await response.arrayBuffer())
+    }
+
+    for (const key of ['assets/keep.png', 'remotes/keep.local.bin']) {
+      await write(key)
+      const response = await client.fetch('/api/remove', {
+        headers: { 'file-path': hex(key) },
+      })
+      expect(response.status).toBe(409)
+      expect(response.headers.get('cache-control')).toBe('no-store')
+      expect(await response.json()).toMatchObject({
+        code: 'DIRECT_ASSET_REMOVE_DISABLED',
+      })
+      expect(await read(key)).toEqual(Buffer.from([1, 2, 3]))
+    }
+
+    await write('draft/delete.bin')
+    const remove = await client.fetch('/api/remove', {
+      headers: { 'file-path': hex('draft/delete.bin') },
+    })
+    expect(remove.ok).toBe(true)
+    expect(remove.headers.get('cache-control')).toBe('no-store')
+    expect(await read('draft/delete.bin')).toHaveLength(0)
+  })
+})

--- a/test/compat/orphan-cleanup-scan.test.ts
+++ b/test/compat/orphan-cleanup-scan.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, describe, expect, test } from 'vitest'
+import { spawnServer, type ServerHandle } from './helpers/spawnServer.js'
+import { createClient } from './helpers/client.js'
+import { createSeedBackup } from './helpers/seed.js'
+
+const servers: ServerHandle[] = []
+afterAll(async () => {
+  await Promise.allSettled(servers.map(server => server.cleanup()))
+})
+
+const hex = (value: string) => Buffer.from(value, 'utf-8').toString('hex')
+
+describe('confirmed orphan cleanup scan', () => {
+  test('deletes only reviewed candidates that remain eligible', async () => {
+    const server = await spawnServer()
+    servers.push(server)
+    const client = await createClient(server.port, server.password)
+    await client.importBackup(createSeedBackup({ characterCount: 0 }))
+    await client.fetch('/api/read', {
+      headers: { 'file-path': hex('database/database.bin') },
+    })
+    const sessionId = 'cleanup-intersection'
+
+    await client.fetch('/api/session', {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId },
+    })
+
+    const write = async (key: string, data: Uint8Array) => {
+      const response = await client.fetch('/api/write', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/octet-stream',
+          'file-path': hex(key),
+          'x-session-id': sessionId,
+          'x-user-active': '1',
+        },
+        body: data,
+      })
+      expect(response.ok).toBe(true)
+    }
+    const read = async (key: string) => {
+      const response = await client.fetch('/api/read', {
+        headers: { 'file-path': hex(key) },
+      })
+      return Buffer.from(await response.arrayBuffer())
+    }
+    const makeOldRemote = async (name: string) => {
+      await write(`remotes/${name}.local.bin`, new Uint8Array([1, 2, 3]))
+      await write(
+        `remotes/${name}.local.bin.meta`,
+        new TextEncoder().encode(JSON.stringify({ lastUsed: 1 })),
+      )
+    }
+
+    await makeOldRemote('a')
+    await makeOldRemote('b')
+    const dryResponse = await client.fetch('/api/cleanup/orphan-assets', {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId },
+    })
+    expect(dryResponse.ok).toBe(true)
+    const dry = await dryResponse.json() as {
+      scanId: string
+      expiresAt: number
+      count: number
+    }
+    expect(dry.scanId).toEqual(expect.any(String))
+    expect(dry.expiresAt).toBeGreaterThan(Date.now())
+    expect(dry.count).toBe(2)
+
+    // A is no longer stale; C became orphaned only after the reviewed scan.
+    await write(
+      'remotes/a.local.bin.meta',
+      new TextEncoder().encode(JSON.stringify({ lastUsed: Date.now() })),
+    )
+    await makeOldRemote('c')
+
+    const confirm = await client.fetch('/api/cleanup/orphan-assets?confirm=true', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-session-id': sessionId,
+      },
+      body: JSON.stringify({ scanId: dry.scanId }),
+    })
+    expect(confirm.ok).toBe(true)
+    expect(await confirm.json()).toMatchObject({
+      count: 1,
+      requestedCount: 2,
+      skippedCount: 1,
+    })
+    expect(await read('remotes/a.local.bin')).toHaveLength(3)
+    expect(await read('remotes/b.local.bin')).toHaveLength(0)
+    expect(await read('remotes/c.local.bin')).toHaveLength(3)
+
+    const retry = await client.fetch('/api/cleanup/orphan-assets?confirm=true', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-session-id': sessionId,
+      },
+      body: JSON.stringify({ scanId: dry.scanId }),
+    })
+    expect(retry.status).toBe(409)
+    expect(await read('remotes/c.local.bin')).toHaveLength(3)
+  })
+
+  test('rejects replaced and cross-session scans without deleting', async () => {
+    const server = await spawnServer()
+    servers.push(server)
+    const client = await createClient(server.port, server.password)
+    await client.importBackup(createSeedBackup({ characterCount: 0 }))
+    await client.fetch('/api/read', {
+      headers: { 'file-path': hex('database/database.bin') },
+    })
+    const sessionId = 'cleanup-scan-owner'
+
+    await client.fetch('/api/session', {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId },
+    })
+    const write = await client.fetch('/api/write', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/octet-stream',
+        'file-path': hex('remotes/keep.local.bin'),
+        'x-session-id': sessionId,
+        'x-user-active': '1',
+      },
+      body: new Uint8Array([9]),
+    })
+    expect(write.ok).toBe(true)
+    await client.fetch('/api/write', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/octet-stream',
+        'file-path': hex('remotes/keep.local.bin.meta'),
+        'x-session-id': sessionId,
+        'x-user-active': '1',
+      },
+      body: new TextEncoder().encode(JSON.stringify({ lastUsed: 1 })),
+    })
+
+    const scan = async (sid: string) => {
+      const response = await client.fetch('/api/cleanup/orphan-assets', {
+        method: 'POST',
+        headers: { 'x-session-id': sid, 'x-user-active': '1' },
+      })
+      expect(response.ok).toBe(true)
+      return (await response.json() as { scanId: string }).scanId
+    }
+    const confirm = (scanId: string, sid: string) => client.fetch(
+      '/api/cleanup/orphan-assets?confirm=true',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-session-id': sid,
+          'x-user-active': '1',
+        },
+        body: JSON.stringify({ scanId }),
+      },
+    )
+
+    const replaced = await scan(sessionId)
+    const current = await scan(sessionId)
+    expect((await confirm(replaced, sessionId)).status).toBe(409)
+
+    await client.fetch('/api/session', {
+      method: 'POST',
+      headers: { 'x-session-id': 'cleanup-other-session' },
+    })
+    expect((await confirm(current, 'cleanup-other-session')).status).toBe(409)
+    const read = await client.fetch('/api/read', {
+      headers: { 'file-path': hex('remotes/keep.local.bin') },
+    })
+    expect(Buffer.from(await read.arrayBuffer())).toEqual(Buffer.from([9]))
+  })
+})


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
        - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

This PR fixes an asset-loss issue where assets still in use could be
permanently deleted.

In upstream RisuAI, `cleanChunks()` operates on a local DB and assets stored
by the same client. PocketRisu moved that data to a server-backed HTTP KV
store, but retained cleanup based on the DB currently loaded by one client.
At boot, assets missing from that DB's reference list could therefore be
deleted from the shared server through `GET /api/remove`.

This change removes the boot-time automatic deletion path, blocks legacy
direct deletion of asset namespaces, and replaces the lost reclamation path
with a manual, server-validated cleanup.

## Related Issues

None.

## Changes

Stops the data loss — these two commits stand alone:

- `7dd100f8` Removed the boot-time `cleanChunks()` call and its client-side
    deletion loop.
- `d90719ff` Blocked legacy direct removal of `assets/*` and `remotes/*`
    keys via `GET /api/remove` (409). No current code path removes these keys
    through that endpoint other than the removed boot cleanup, so normal
    removal behavior is unaffected. On older clients, the 409 aborts the
    boot-time deletion loop on its first request.

Replacement cleanup feature (additive and optional — can be dropped
without affecting the first two commits):

- `6b21bc38` Added `POST /api/cleanup/orphan-assets`. Dry-run by default;
    deletion happens only through a one-time scan token and re-validates each
    candidate against the current server state before deleting. Candidates are
    computed from the server's DB view (`buildUncleanableSet`, extended to
    also protect indirectly referenced asset paths) and must be older than a
    7-day grace period. The endpoint runs under the active-session check and
    the storage queue.
- `b8889082` Added the manual cleanup action to the storage dashboard.

Tests:

- `b1f0bf2d` Added 14 tests across three files (see Verification).

## Impact

PocketRisu no longer automatically deletes server assets during client boot.
Orphan cleanup now requires an explicit dashboard action and confirmation.
Legacy direct removal of asset and remote keys returns 409, while removal in
other KV namespaces keeps its existing behavior.

Verification:

Existing suites pass unchanged (all skips noted are pre-existing and
unrelated to this PR):

- `pnpm test`: 69 files, 1,040 passed, 3 skipped; server Vitest 110 passed.
- `pnpm test:compat`: 70 passed, 5 skipped.
- `pnpm check`: 0 errors (4 pre-existing a11y warnings).

This PR adds 14 tests, all passing (included above):

- `server/node/orphanCleanup.test.ts` (11) — orphan candidate rules: grace
    period, reference-set membership, invalid timestamps, corrupt remote
    metadata, and indirect-reference protection (GPT-SoVITS, nested plugins).
- `test/compat/legacy-remove-guard.test.ts` (1) — `GET /api/remove` returns
    409 for assets/remotes and still deletes other KV namespaces.
- `test/compat/orphan-cleanup-scan.test.ts` (2) — confirm deletes only
    reviewed, still-eligible candidates; replaced/reused/cross-session scans
    are rejected without deleting.

Skips: 3 default-suite skips are parser FIXMEs (ChatML end-token,
greedy-thoughts regex, CBS `::or` precedence); 5 compat skips run only with a
git-ignored upstream backup fixture.

## Additional Notes

In my environment, switching between multiple clients triggers this asset
loss, which recurs daily and currently makes PocketRisu unusable. Because the
issue is recurring and blocks normal use, I am submitting a concrete fix
directly as a PR rather than opening an issue first. I observe the failure
repeatedly, but I have not isolated consistent steps that intentionally
reproduce the initial reference mismatch.

The removed boot cleanup was the only path that reclaimed orphaned server
storage, so removing it without a replacement would let orphans grow
indefinitely; the manual server-validated cleanup is that replacement. The first two commits, which stop the data loss, are about 70 lines; the
rest is one additive, opt-in feature with tests. If you prefer a different
design — or prefer to take only those two commits — I am happy to split or
drop the cleanup feature part.