### PR TITLE
Update retired Claude model ids in the OAI2 preset

### DIFF
--- a/src/ts/process/templates/templates.ts
+++ b/src/ts/process/templates/templates.ts
@@ -243,7 +243,7 @@ export const prebuiltPresets: Record<string, botPreset> = {
       "globalNote",
       "authorNote"
     ],
-    "aiModel": "claude-3-5-sonnet-20240620",
+    "aiModel": "claude-sonnet-4-6",
     "subModel": "gemini-3-flash-preview",
     "currentPluginProvider": "",
     "textgenWebUIStreamURL": "",
@@ -298,7 +298,7 @@ export const prebuiltPresets: Record<string, botPreset> = {
       "stoptokens": "",
       "top_k": 140
     },
-    "proxyRequestModel": "claude-3-5-sonnet-20240620",
+    "proxyRequestModel": "claude-sonnet-4-6",
     "openrouterRequestModel": "anthropic/claude-2",
     "NAISettings": {
       "topK": 12,
@@ -385,7 +385,7 @@ export const prebuiltPresets: Record<string, botPreset> = {
     "NAIadventure": false,
     "NAIappendName": true,
     "autoSuggestPrompt": "",
-    "customProxyRequestModel": "claude-3-5-sonnet-20240620",
+    "customProxyRequestModel": "claude-sonnet-4-6",
     "reverseProxyOobaArgs": {
       "mode": "instruct"
     },


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? No new types. This is three string literals inside `botPreset`, which is already typed.
    - [x] Have you tested your changes? `pnpm check` reports 0 errors. See Additional Notes for what I did not test.
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models:
    - [x] Have you checked if it works normally in all models / providers? The new id is already an entry in `AnthropicModels`, so it resolves the way any other listed model does. The two proxy fields are passed through to whatever endpoint the user has configured, same as before.
- [x] If your PR is highly AI generated:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change? Three lines.

## Summary

The three Claude model fields in the OAI2 "Default Prompt" preset point at `claude-3-5-sonnet-20240620`, which Anthropic retired on 28 October 2025.

## Related Issues

None.

## Changes

| Line in `src/ts/process/templates/templates.ts` | Field | Was | Now |
| --- | --- | --- | --- |
| 246 | `aiModel` | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` |
| 301 | `proxyRequestModel` | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` |
| 388 | `customProxyRequestModel` | `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` |

Retirement dates come from Anthropic's deprecations page, https://platform.claude.com/docs/en/about-claude/model-deprecations

I picked `claude-sonnet-4-6` because it is already in your catalogue at `src/ts/model/providers/anthropic.ts:27` with `recommended: true`, and because the value being replaced was Sonnet, so the tier stays the same. Swap it for whichever entry you would rather ship as the default and I will amend.

Three other places that a careless pass would also have rewritten are left alone.

`src/ts/model/providers/anthropic.ts` holds fourteen retired ids and should keep all of them. That file is the selectable list, each id is paired with its own display name, and a user whose save points at `claude-3-opus-20240229` needs that entry to stay resolvable.

`src/ts/model/modellist.ts` is the Bedrock catalogue and the same reasoning applies.

`templates.ts:302` sets `openrouterRequestModel` to `anthropic/claude-2`. That is OpenRouter's namespace rather than Anthropic's and I have not checked what OpenRouter serves today, so I left it for you.

## Impact

Existing saves are untouched. `setPreset` writes these three fields only when a preset is loaded, so this reaches anyone who creates a preset from OAI2 in the settings panel after it lands.

## Additional Notes

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run the app against the Anthropic API to reproduce a failed request, so the claim rests on the published retirement dates rather than on a status code I watched come back. What I did run is `pnpm check`, which reports 0 errors on this branch. It also reports 4 accessibility warnings in `DefaultChatScreen.svelte`, and those are already on `main` and have nothing to do with this change. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
