### PR TITLE
feat: restore last active chat after reload

### DIFF
--- a/src/lib/Mobile/MobileHeader.svelte
+++ b/src/lib/Mobile/MobileHeader.svelte
@@ -5,6 +5,7 @@
     import { DBState } from 'src/ts/stores.svelte';
     import { MobileGUIStack, MobileSearch, selectedCharID, SettingsMenuIndex, MobileSideBar } from "src/ts/stores.svelte";
     import { SettingsRoute } from "src/ts/routing";
+    import { deselectCharacter } from "src/ts/characters";
 
 </script>
 <div class="w-full px-4 h-16 border-b border-b-darkborderc bg-darkbg flex justify-start items-center gap-2">
@@ -17,7 +18,7 @@
         <span class="font-bold text-lg w-2/3 truncate">{language.menu}</span>
     {:else if $selectedCharID !== -1}
         <button onclick={() => {
-            selectedCharID.set(-1)
+            deselectCharacter()
         }}>
             <ArrowLeft />
         </button>

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -38,6 +38,7 @@
     import {
   addCharacter,
     changeChar,
+    deselectCharacter,
     getCharImage,
   } from "../../ts/characters";
     import CharConfig from "./CharConfig.svelte";
@@ -562,7 +563,7 @@
   )}
   onclick={() => {
     reseter();
-    selectedCharID.set(-1)
+    deselectCharacter()
     PlaygroundStore.set(0)
     OpenRealmStore.set(false)
   }}
@@ -608,7 +609,7 @@
   )}
   onclick={() => {
     reseter();
-    selectedCharID.set(-1)
+    deselectCharacter()
     PlaygroundStore.set(1)
   }}
 >
@@ -661,7 +662,7 @@
       <BarIcon
         onClick={() => {
           reseter();
-          selectedCharID.set(-1)
+          deselectCharacter()
           PlaygroundStore.set(0)
           OpenRealmStore.set(false)
         }}><HomeIcon /></BarIcon>
@@ -673,7 +674,7 @@
             PlaygroundStore.set(0)
             return
           }
-          selectedCharID.set(-1)
+          deselectCharacter()
           PlaygroundStore.set(1)
         }}
       ><ShellIcon /></BarIcon>
@@ -1016,7 +1017,7 @@
       <BarIcon
         onClick={() => {
           reseter();
-          selectedCharID.set(-1)
+          deselectCharacter()
           PlaygroundStore.set(0)
           OpenRealmStore.set(false)
         }}><HomeIcon /></BarIcon>
@@ -1028,7 +1029,7 @@
             PlaygroundStore.set(0)
             return
           }
-          selectedCharID.set(-1)
+          deselectCharacter()
           PlaygroundStore.set(1)
         }}
       ><ShellIcon /></BarIcon>

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -17,7 +17,7 @@ import { updateColorScheme, updateTextThemeAndCSS } from "./gui/colorscheme";
 import { applyEarlyLanguage, changeLanguage, language } from "src/lang";
 import { startObserveDom } from "./observer.svelte";
 import { updateGuisize } from "./gui/guisize";
-import { updateLorebooks } from "./characters";
+import { changeChar, updateLorebooks } from "./characters";
 import { initMobileGesture } from "./hotkey";
 import { moduleUpdate } from "./process/modules";
 import {
@@ -170,7 +170,30 @@ export async function loadData() {
                 console.warn('[bootstrap] boot backup reminder failed:', err)
             }
             loadedStore.set(true)
+
             selectedCharID.set(-1)
+
+            // Keep PocketRisu's normal clean boot (-1), then restore through
+            // the canonical changeChar path so lazy chat hydration, toggles,
+            // and chat UI initialization still run normally.
+            try {
+                const lastChaId = localStorage.getItem('risu-last-active-character')
+                const restoreIndex = lastChaId
+                    ? DBState.db.characters.findIndex((char) => char?.chaId === lastChaId)
+                    : -1
+
+                if (restoreIndex >= 0) {
+                    setTimeout(() => {
+                        try {
+                            changeChar(restoreIndex)
+
+                        } catch (error) {
+                            console.warn('[MobileResume] restore failed:', error)
+                        }
+                    }, 100)
+                }
+            } catch { /* best effort only */ }
+
             startObserveDom()
             assignIds()
             registerModelDynamic()

--- a/src/ts/characterCards.ts
+++ b/src/ts/characterCards.ts
@@ -1669,6 +1669,12 @@ export async function downloadRisuHub(id:string, arg:{
                 const index = db.characters.length-1
                 characterFormatUpdate(index);
                 selectedCharID.set(index);
+                try {
+                    const char = db.characters[index]
+                    if (char?.chaId) {
+                        localStorage.setItem('risu-last-active-character', char.chaId)
+                    }
+                } catch {}
             }   
             return
         }
@@ -1686,6 +1692,12 @@ export async function downloadRisuHub(id:string, arg:{
             const index = db.characters.length-1
             characterFormatUpdate(index);
             selectedCharID.set(index);
+            try {
+                const char = db.characters[index]
+                if (char?.chaId) {
+                    localStorage.setItem('risu-last-active-character', char.chaId)
+                }
+            } catch {}
             alertStore.set({
                 type: 'none',
                 msg: ''

--- a/src/ts/characters.ts
+++ b/src/ts/characters.ts
@@ -698,6 +698,15 @@ export function createBlankChar():character{
 }
 
 
+export function deselectCharacter() {
+    try {
+        localStorage.removeItem('risu-last-active-character')
+    } catch {
+        // Best effort only.
+    }
+    selectedCharID.set(-1)
+}
+
 export async function removeChar(identifier:string|number,name:string, type:'normal'|'permanent'|'permanentForce' = 'normal'){
     const db = getDatabase()
     if(type !== 'permanentForce'){
@@ -728,7 +737,7 @@ export async function removeChar(identifier:string|number,name:string, type:'nor
     checkCharOrder()
     db.characters = chars
     requiresFullEncoderReload.state = true
-    selectedCharID.set(-1)
+    deselectCharacter()
 }
 
 export async function addCharacter(arg:{
@@ -738,7 +747,7 @@ export async function addCharacter(arg:{
     const reseter = arg.reseter ?? (() => {})
     const r = await alertAddCharacter()
     if(r === 'importFromRealm'){
-        selectedCharID.set(-1)
+        deselectCharacter()
         OpenRealmStore.set(true)
         MobileGUIStack.set(0)
         return
@@ -779,6 +788,15 @@ export function changeChar(index: number, arg:{
       updateInteraction: true,
     });
     selectedCharID.set(index);
+
+    // Remember only canonical, successfully selected characters.
+    // Android/Firefox may recreate the tab while PocketRisu is backgrounded.
+    try {
+        if (char?.chaId) {
+            localStorage.setItem('risu-last-active-character', char.chaId)
+        }
+    } catch { /* best effort only */ }
+
     const chat = getCurrentChat()
     if(chat){
         if(chat._placeholder){

--- a/src/ts/hotkey.ts
+++ b/src/ts/hotkey.ts
@@ -9,6 +9,7 @@ import { doingChat, previewBody, sendChat } from "./process/index.svelte"
 import { endAllGenerations } from "./process/generationState"
 import { RISU_SIDEBAR_DRAG_TYPE } from "./dragTypes"
 import { openSettings, SettingsRoute, SystemTab } from "./routing"
+import { deselectCharacter } from "./characters"
 
 export function initHotkey(){
     document.addEventListener('keydown', async (ev) => {
@@ -75,7 +76,7 @@ export function initHotkey(){
                     break
                 }
                 case 'home':{
-                    selectedCharID.set(-1)
+                    deselectCharacter()
                     break
                 }
                 case 'presets':{
@@ -105,6 +106,12 @@ export function initHotkey(){
                         return
                     }
                     selectedCharID.set(sorted[currentIndex - 1].i)
+                    try {
+                        const char = database.characters[sorted[currentIndex - 1].i]
+                        if (char?.chaId) {
+                            localStorage.setItem('risu-last-active-character', char.chaId)
+                        }
+                    } catch {}
                     PlaygroundStore.set(0)
                     OpenRealmStore.set(false)
                     break
@@ -120,6 +127,12 @@ export function initHotkey(){
                     // currentIndex === -1 (nothing selected) intentionally falls through
                     // to sorted[0], matching the previous behaviour.
                     selectedCharID.set(sorted[currentIndex + 1].i)
+                    try {
+                        const char = database.characters[sorted[currentIndex + 1].i]
+                        if (char?.chaId) {
+                            localStorage.setItem('risu-last-active-character', char.chaId)
+                        }
+                    } catch {}
                     PlaygroundStore.set(0)
                     OpenRealmStore.set(false)
                     break


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? (N/A: no new data structures or public types were introduced.)
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Restore the last active character/chat after a page reload or mobile browser tab recreation.

The restore is performed through the existing `changeChar()` path so normal chat hydration and character initialization still run.

## Related Issues

None.

## Changes

- Save the active character ID when a character is selected.
- Restore the saved character after database/bootstrap loading completes.
- Clear the saved character when the user intentionally returns to Home or otherwise deselects the character.
- Keep existing hotkey and character-import selection behavior while updating the saved active character.
- Restore imported/selected characters consistently without changing model request behavior.

## Impact

Users who reload the page, or whose mobile browser recreates the PocketRisu tab while it is in the background, return to their previous character/chat instead of being sent back to Home.

Intentional navigation to Home is preserved: refreshing from Home remains on Home.

The stored character ID is best-effort only. If localStorage is unavailable or the character no longer exists, PocketRisu keeps its normal Home state.

## Additional Notes

Tested locally on Android with Firefox:

- Active chat -> reload -> same character/chat restored.
- Active chat -> intentional Home -> reload -> remains on Home.
- `pnpm check`: 0 errors (4 existing accessibility warnings).
- Production build completed successfully.