### PR TITLE
feat: add native Termux response notifications

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -764,6 +764,84 @@ app.use('/assets', express.static(path.join(process.cwd(), 'dist/assets'), {
 }));
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false, maxAge: 0}));
 app.use(express.json({ limit: '100mb' }));
+
+// PocketRisu -> Termux native Android notification
+app.post('/api/termux-notify', (req, res) => {
+    const addr = String(req.socket.remoteAddress || '');
+    const isLoopback =
+        addr === '127.0.0.1' ||
+        addr === '::1' ||
+        addr === '::ffff:127.0.0.1';
+
+    if (!isLoopback) {
+        return res.status(403).json({ error: 'localhost only' });
+    }
+
+    const prefix = process.env.PREFIX;
+
+    if (!prefix) {
+        return res.status(503).json({
+            error: 'Termux environment not available'
+        });
+    }
+
+    const bin = path.join(prefix, 'bin', 'termux-notification');
+
+    if (!existsSync(bin)) {
+        return res.status(503).json({
+            error: 'termux-notification not installed'
+        });
+    }
+
+    const elapsedMs = Number(req.body?.elapsedMs);
+
+    const elapsedText = Number.isFinite(elapsedMs)
+        ? `${(elapsedMs / 1000).toFixed(1)}s`
+        : 'time unavailable';
+
+    const character =
+        typeof req.body?.character === 'string'
+            ? req.body.character.trim().slice(0, 80)
+            : '';
+
+    const title = character
+        ? `PocketRisu · ${character}`
+        : 'PocketRisu';
+
+    // Reuse one notification slot so repeated responses do not stack.
+    const child = spawn(bin, [
+        '--id', '8472',
+        '--title', title,
+        '--content', `Response complete · ${elapsedText}`,
+        '--priority', 'high',
+        '--sound'
+    ], {
+        stdio: 'ignore'
+    });
+
+    let replied = false;
+
+    child.once('error', (error) => {
+        console.error('[TermuxNotify]', error);
+
+        if (!replied) {
+            replied = true;
+            res.status(500).json({
+                error: 'notification failed'
+            });
+        }
+    });
+
+    child.once('close', (code) => {
+        if (!replied) {
+            replied = true;
+            res.status(code === 0 ? 200 : 500).json({
+                ok: code === 0
+            });
+        }
+    });
+});
+
 app.use((req, res, next) => {
     // Skip express.raw() for backup import — it must stream, not buffer into memory
     if (req.path === '/api/backup/import') return next();

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -66,10 +66,12 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     usedContinueTokens?:number,
     preview?:boolean
     previewPrompt?:boolean
+    responseStartedAt?:number
 } = {}):Promise<boolean> {
 
     chatProcessStage.set(0)
     const abortSignal = arg.signal ?? (new AbortController()).signal
+    const responseStartedAt = arg.responseStartedAt ?? performance.now()
     
     // NOTE: `throwError()` can be called before these are populated (e.g. HypaV3 early validation errors).
     // Keep them declared up-front to avoid TDZ ReferenceErrors in production builds.
@@ -1768,6 +1770,7 @@ export async function sendChat(chatProcessIndex = -1,arg:{
     if(needsAutoContinue){
         endGeneration(genKey, { keepPendingAbort: true })
         return await sendChat(chatProcessIndex, {
+            responseStartedAt,
             chatAdditonalTokens: arg.chatAdditonalTokens,
             continue: true,
             signal: abortSignal,
@@ -1812,24 +1815,49 @@ export async function sendChat(chatProcessIndex = -1,arg:{
         
         endGeneration(genKey, { keepPendingAbort: true })
         return await sendChat(chatProcessIndex, {
+            responseStartedAt,
             signal: abortSignal
         })
     }
 
     if(DBState.db.notification){
-        try {
-            const permission = await Notification.requestPermission()
-            if(permission === 'granted'){
-                const noti = new Notification('Risuai', {
-                    body: result
+        void (async () => {
+            let termuxNotified = false
+
+            try {
+                const elapsedMs = performance.now() - responseStartedAt
+                const response = await fetch('/api/termux-notify', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        elapsedMs,
+                        character: currentChar?.name ?? ''
+                    })
                 })
-                noti.onclick = () => {
-                    window.focus()
-                }
+
+                termuxNotified = response.ok
+            } catch {}
+
+            if(termuxNotified){
+                return
             }
-        } catch (error) {
-            
-        }
+
+            try {
+                const permission = await Notification.requestPermission()
+                if(permission === 'granted'){
+                    const noti = new Notification('Risuai', {
+                        body: result
+                    })
+                    noti.onclick = () => {
+                        window.focus()
+                    }
+                }
+            } catch (error) {
+
+            }
+        })()
     }
 
     if(req.special){


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? (N/A: no new public types were introduced.)
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add native Android response notifications when PocketRisu is running locally under Termux.

The existing browser Notification API is preserved as a fallback when the Termux notification endpoint is unavailable.

## Related Issues

None.

## Changes

- Add a localhost-only `/api/termux-notify` endpoint.
- Use `termux-notification` when running in a Termux environment.
- Show the active character name and total response time in the native notification.
- Preserve the initial response start time across auto-continue/resend calls.
- Keep the existing browser notification behavior as a fallback.
- Reuse a fixed notification ID so repeated responses do not stack notifications.

## Impact

Users running PocketRisu locally on Android through Termux can receive native Android notifications when a response finishes.

Other environments are unaffected: if Termux or `termux-notification` is unavailable, PocketRisu falls back to the existing browser notification behavior.

The native endpoint only accepts loopback requests.

## Additional Notes

Tested locally on Android with Firefox and Termux:

- Native notification appears after response completion.
- Notification sound plays once per completed response without continuously repeating.
- Repeated responses update the notification without stacking multiple notifications.
- Disabling PocketRisu notifications prevents response notifications.
- `pnpm check`: 0 errors (4 existing accessibility warnings).
- Production build completed successfully.