### PR TITLE
feat: add NovelAI Diffusion V5 model options

### DIFF
--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -291,6 +291,8 @@
 
             <span class="text-textcolor">Model <Help key="naiModel"/></span>
             <SelectInput className="mt-2 mb-4" bind:value={DBState.db.NAIImgModel} >
+                <OptionInput value="nai-diffusion-5-full" >nai-diffusion-5-full</OptionInput>
+                <OptionInput value="nai-diffusion-5-curated" >nai-diffusion-5-curated</OptionInput>
                 <OptionInput value="nai-diffusion-4-5-full" >nai-diffusion-4-5-full</OptionInput>
                 <OptionInput value="nai-diffusion-4-5-curated" >nai-diffusion-4-5-curated</OptionInput>
                 <OptionInput value="nai-diffusion-4-full" >nai-diffusion-4-full</OptionInput>
@@ -307,7 +309,9 @@
             <NumberInput className="mt-2" marginBottom min={0} max={2048} bind:value={DBState.db.NAIImgConfig.height}/>
             <span class="text-textcolor">Sampler <Help key="naiSampler"/></span>
 
-            {#if DBState.db.NAIImgModel === 'nai-diffusion-4-full'
+            {#if DBState.db.NAIImgModel === 'nai-diffusion-5-full'
+            || DBState.db.NAIImgModel === 'nai-diffusion-5-curated'
+            || DBState.db.NAIImgModel === 'nai-diffusion-4-full'
             || DBState.db.NAIImgModel === 'nai-diffusion-4-curated-preview'
             || DBState.db.NAIImgModel === 'nai-diffusion-4-5-full'
             || DBState.db.NAIImgModel === 'nai-diffusion-4-5-curated'}
@@ -349,7 +353,9 @@
             <span class="text-textcolor">Image Reference <Help key="naiImageReference"/></span>
             <SelectInput className="mt-2 mb-4" bind:value={DBState.db.NAIImgConfig.reference_mode}>
                 <OptionInput value="" >None</OptionInput>
-                <OptionInput value="vibe" >Vibe Trasfer</OptionInput>
+                {#if DBState.db.NAIImgModel !== 'nai-diffusion-5-full' && DBState.db.NAIImgModel !== 'nai-diffusion-5-curated'}
+                    <OptionInput value="vibe" >Vibe Trasfer</OptionInput>
+                {/if}
                 {#if DBState.db.NAIImgModel === 'nai-diffusion-4-5-full' || DBState.db.NAIImgModel === 'nai-diffusion-4-5-curated'}
                     <OptionInput value="character" >Character Reference</OptionInput>
                 {/if}

--- a/src/ts/process/stableDiff.ts
+++ b/src/ts/process/stableDiff.ts
@@ -213,8 +213,10 @@ export async function generateAIImage(genPrompt:string, currentChar:character, n
             }
         }
 
-        // Add vibe reference_image_multiple if exists
-        if(db.NAIImgConfig.reference_mode === 'vibe' && db.NAIImgConfig.vibe_data) {
+        // Add vibe reference_image_multiple if exists. V5 does not support
+        // Vibe Transfer yet, so ignore a persisted V4/V4.5 reference setting.
+        const isNAIV5Model = db.NAIImgModel === 'nai-diffusion-5-full' || db.NAIImgModel === 'nai-diffusion-5-curated';
+        if(!isNAIV5Model && db.NAIImgConfig.reference_mode === 'vibe' && db.NAIImgConfig.vibe_data) {
             const vibeData = db.NAIImgConfig.vibe_data;
             // Determine which model to use based on vibe_model_selection or fallback to current model
             const modelKey = db.NAIImgConfig.vibe_model_selection || 


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? No new type definitions were required; the existing model setting uses a string value.
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [x] Have you checked if it works normally in all models / providers? The change is limited to NovelAI model selection, and existing models/providers remain unchanged.
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - This is a focused two-file change.

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Adds NovelAI Diffusion V5 Full and V5 Curated to the image generation model selector.

The existing NovelAI request flow already forwards the selected model ID directly to the image generation API, so this PR adds the missing UI options and applies the appropriate sampler and Vibe Transfer handling.

## Related Issues

Closes #63

## Changes

- Added `nai-diffusion-5-full` to the NovelAI model selector.
- Added `nai-diffusion-5-curated` to the NovelAI model selector.
- Reused the existing V4-family sampler list supported by V5.
- Hid Vibe Transfer settings when a V5 model is selected.
- Prevented stale Vibe Transfer settings from being included in V5 requests.

## Impact

Users can select NovelAI Diffusion V5 Full or V5 Curated without using a browser developer-console workaround.

Other NovelAI models and image-generation providers are unaffected.

## Additional Notes

- Verified that PocketRisu sends `nai-diffusion-5-full` as the request body's `model` value.
- V5-specific features such as Character Reference and Variety+ are intentionally outside the scope of this minimal model-support PR.
- Type checking completed with 0 errors.
- Production build completed successfully.
- Main test suite: 1040 passed, 3 skipped.
- Server test suite: 99 passed.
- Compatibility test suite: 67 passed, 5 skipped.