### PR TITLE
perf: skip empty patches and avoid full DB encode for patch ETag

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -3800,6 +3800,25 @@ app.post('/api/patch', async (req, res, next) => {
                 return;
             }
 
+            // A diff-based client can legitimately send an empty patch. Keep
+            // the current revision in that case and skip clone/apply/save work.
+            if (patch.length === 0) {
+                if (decodedKey === 'database/database.bin' && !dbEtag) {
+                    dbEtag = computeBufferEtag(Buffer.from(encodeRisuSaveLegacy(dbCache[filePath])));
+                }
+                const responsePayload = {
+                    success: true,
+                    appliedOperations: 0,
+                    etag: decodedKey === 'database/database.bin' ? dbEtag : undefined,
+                };
+                const persistWarning = currentPersistWarning();
+                if (persistWarning) {
+                    responsePayload.persistWarning = persistWarning;
+                }
+                res.send(responsePayload);
+                return;
+            }
+
             // Apply patch to in-memory database (clone first to prevent partial
             // mutation on failure). structuredClone instead of a JSON round-trip:
             // stringifying the whole DB into one JS string hits V8's ~512MB
@@ -3856,10 +3875,12 @@ app.post('/api/patch', async (req, res, next) => {
                 }
             }, SAVE_INTERVAL);
 
-            // Update ETag after successful patch (based on stripped version)
+            // The ETag is only used as an opaque revision token for conflict
+            // detection. Avoid re-encoding and hashing the entire stripped DB
+            // after every successful patch just to mint the next revision.
             patchStage = 'etag';
             if (decodedKey === 'database/database.bin') {
-                dbEtag = computeBufferEtag(Buffer.from(encodeRisuSaveLegacy(dbCache[filePath])));
+                dbEtag = `rev-${nodeCrypto.randomUUID()}`;
             }
 
             const responsePayload = {


### PR DESCRIPTION
PR Checklist

[ ] Have you added type definitions?
[x] Have you tested your changes?
[x] Have you checked that it won't break any existing features?
[x] Have you understood what the code does?
[x] Have you cleaned up unnecessary or redundant code?
[x] Is it not a huge change?

Summary

Reduce unnecessary work in the Node /api/patch save path for large databases.
Empty patches now return immediately without cloning, applying, or scheduling a save. Successful non-empty database patches use an opaque revision ETag instead of re-encoding and MD5-hashing the entire stripped database only to generate the next ETag.

Related Issues

None.

Changes

Add an early return for patch.length === 0.
Preserve the existing database ETag for empty patches.
Skip clone/apply/save work for empty patches.
Replace the post-patch full-database encode + MD5 operation with a fresh opaque revision token.
Keep the existing x-if-match conflict-check behavior unchanged.

Impact

This mainly benefits Node/self-host users with large databases, where encoding and hashing the full database after every patch can be expensive.
Database format, persistence format, JSON Patch semantics, chat storage, and conflict detection behavior are unchanged.
Additional Notes
This PR intentionally contains only the first isolated optimization stage.
Compositional hash caching, selective cloning, and deeper pluginCustomStorage optimizations are intentionally excluded and can be reviewed separately.