### PR TITLE
perf: cache compositional DB patch hash

### DIFF
--- a/server/node/patch-hash-cache.cjs
+++ b/server/node/patch-hash-cache.cjs
@@ -1,0 +1,126 @@
+'use strict';
+
+const PRIME_MULTIPLIER = 31;
+const SEED_OBJECT = 17;
+
+function decodePointerSegment(segment) {
+    return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function collectTouchedTopLevelKeys(patch) {
+    const keys = new Set();
+    let touchesRoot = false;
+
+    for (const op of Array.isArray(patch) ? patch : []) {
+        for (const field of ['path', 'from']) {
+            const pointer = op?.[field];
+            if (typeof pointer !== 'string') continue;
+            if (pointer === '') {
+                touchesRoot = true;
+                continue;
+            }
+            if (!pointer.startsWith('/')) {
+                touchesRoot = true;
+                continue;
+            }
+            const nextSlash = pointer.indexOf('/', 1);
+            const rawSegment = nextSlash === -1
+                ? pointer.slice(1)
+                : pointer.slice(1, nextSlash);
+            keys.add(decodePointerSegment(rawSegment));
+        }
+    }
+
+    return { keys, touchesRoot };
+}
+
+function createPatchHashCache(calculateHash) {
+    if (typeof calculateHash !== 'function') {
+        throw new TypeError('calculateHash must be a function');
+    }
+
+    const states = new WeakMap();
+
+    function isObjectRoot(database) {
+        return database !== null && typeof database === 'object' && !Array.isArray(database);
+    }
+
+    function buildState(database) {
+        if (!isObjectRoot(database)) {
+            return { valueHashes: null, fullHash: calculateHash(database) };
+        }
+
+        const valueHashes = new Map();
+        for (const key in database) {
+            valueHashes.set(key, calculateHash(database[key]));
+        }
+        return { valueHashes, fullHash: null };
+    }
+
+    function getState(database) {
+        if (!isObjectRoot(database)) return buildState(database);
+        let state = states.get(database);
+        if (!state) {
+            state = buildState(database);
+            states.set(database, state);
+        }
+        return state;
+    }
+
+    function compose(database, state) {
+        if (!isObjectRoot(database) || state.valueHashes === null) {
+            return state.fullHash ?? calculateHash(database);
+        }
+
+        let rootHash = SEED_OBJECT;
+        for (const key in database) {
+            let valueHash = state.valueHashes.get(key);
+            if (valueHash === undefined && !state.valueHashes.has(key)) {
+                valueHash = calculateHash(database[key]);
+                state.valueHashes.set(key, valueHash);
+            }
+            rootHash += Math.imul(calculateHash(key), PRIME_MULTIPLIER) + valueHash;
+        }
+        return rootHash >>> 0;
+    }
+
+    function hash(database) {
+        return compose(database, getState(database));
+    }
+
+    function update(previousDatabase, nextDatabase, patch) {
+        if (!isObjectRoot(nextDatabase)) {
+            return calculateHash(nextDatabase);
+        }
+
+        const previousState = isObjectRoot(previousDatabase)
+            ? getState(previousDatabase)
+            : null;
+        const { keys, touchesRoot } = collectTouchedTopLevelKeys(patch);
+
+        let nextState;
+        if (touchesRoot || !previousState || previousState.valueHashes === null) {
+            nextState = buildState(nextDatabase);
+        } else {
+            const valueHashes = new Map(previousState.valueHashes);
+            for (const key of keys) {
+                if (Object.prototype.hasOwnProperty.call(nextDatabase, key)) {
+                    valueHashes.set(key, calculateHash(nextDatabase[key]));
+                } else {
+                    valueHashes.delete(key);
+                }
+            }
+            nextState = { valueHashes, fullHash: null };
+        }
+
+        states.set(nextDatabase, nextState);
+        return compose(nextDatabase, nextState);
+    }
+
+    return { hash, update };
+}
+
+module.exports = {
+    createPatchHashCache,
+    collectTouchedTopLevelKeys,
+};

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -33,6 +33,7 @@ const {
 const { createRequestLogs } = require('./request-logs.cjs');
 const { applyPatch } = require('fast-json-patch');
 const { decodeRisuSave, encodeRisuSaveLegacy, calculateHash, normalizeJSON, normalizeForwardHeaders, hasRemoteBlocks } = require('./utils.cjs');
+const { createPatchHashCache } = require('./patch-hash-cache.cjs');
 const { spawn, execSync } = require('child_process');
 const os = require('os');
 const { Readable, Transform } = require('stream');
@@ -56,6 +57,7 @@ let dbCache = {};
 let saveTimers = {};
 const SAVE_INTERVAL = 5000;
 let fullChatStore = null; // Map<chaId, Map<chatId, chatObject>> — lazy-initialized
+const databasePatchHashCache = createPatchHashCache(calculateHash);
 
 // ETag for database.bin
 let dbEtag = null;
@@ -3784,7 +3786,9 @@ app.post('/api/patch', async (req, res, next) => {
             }
 
             patchStage = 'hash';
-            const serverHash = calculateHash(dbCache[filePath]).toString(16);
+            const serverHash = decodedKey === 'database/database.bin'
+                ? databasePatchHashCache.hash(dbCache[filePath]).toString(16)
+                : calculateHash(dbCache[filePath]).toString(16);
 
             if (expectedHash !== serverHash) {
                 console.log(`[Patch] Hash mismatch for ${decodedKey}: expected=${expectedHash}, server=${serverHash}`);
@@ -3819,6 +3823,9 @@ app.post('/api/patch', async (req, res, next) => {
                 // Invalidate corrupted cache entry to force reload on next request
                 delete dbCache[filePath];
                 throw patchErr;
+            }
+            if (decodedKey === 'database/database.bin') {
+                databasePatchHashCache.update(dbCache[filePath], snapshot, patch);
             }
             dbCache[filePath] = snapshot;
 

--- a/test/patch-hash-cache.test.ts
+++ b/test/patch-hash-cache.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import patchHashPkg from '../server/node/patch-hash-cache.cjs'
+import utilsPkg from '../server/node/utils.cjs'
+import jsonPatchPkg from 'fast-json-patch'
+
+const { createPatchHashCache, collectTouchedTopLevelKeys } = patchHashPkg as {
+    createPatchHashCache: (calculateHash: (value: any) => number) => {
+        hash: (database: any) => number
+        update: (previousDatabase: any, nextDatabase: any, patch: any[]) => number
+    }
+    collectTouchedTopLevelKeys: (patch: any[]) => { keys: Set<string>, touchesRoot: boolean }
+}
+const { calculateHash } = utilsPkg as { calculateHash: (value: any) => number }
+const { applyPatch } = jsonPatchPkg
+
+function apply(base: any, patch: any[]) {
+    const next = structuredClone(base)
+    applyPatch(next, patch, true)
+    return next
+}
+
+describe('patch hash cache', () => {
+    it('matches calculateHash on initial object state', () => {
+        const db = {
+            username: 'u',
+            modules: [{ id: 'm1', value: 1 }],
+            pluginCustomStorage: { alpha: { nested: { n: 1 } } },
+            characters: [{ chaId: 'c1', chats: [{ id: 'chat', _stub: true }] }],
+        }
+        const cache = createPatchHashCache(calculateHash)
+        expect(cache.hash(db)).toBe(calculateHash(db))
+    })
+
+    it('matches reference after nested replace and add/remove top-level operations', () => {
+        const cache = createPatchHashCache(calculateHash)
+        let db: any = {
+            username: 'u',
+            pluginCustomStorage: { alpha: { n: 1 }, beta: { n: 2 } },
+            modules: [{ id: 'm1', value: 1 }],
+        }
+        expect(cache.hash(db)).toBe(calculateHash(db))
+
+        const patches = [
+            [{ op: 'replace', path: '/pluginCustomStorage/alpha/n', value: 7 }],
+            [{ op: 'add', path: '/newRoot', value: { ok: true } }],
+            [{ op: 'remove', path: '/modules' }],
+        ]
+
+        for (const patch of patches) {
+            const next = apply(db, patch)
+            expect(cache.update(db, next, patch)).toBe(calculateHash(next))
+            expect(cache.hash(next)).toBe(calculateHash(next))
+            db = next
+        }
+    })
+
+    it('tracks both path and from for cross-root move/copy operations', () => {
+        const cache = createPatchHashCache(calculateHash)
+        let db: any = {
+            left: { a: { value: 1 } },
+            right: { b: { value: 2 } },
+        }
+        expect(cache.hash(db)).toBe(calculateHash(db))
+
+        const movePatch = [{ op: 'move', from: '/left/a', path: '/right/a' }]
+        let next = apply(db, movePatch)
+        expect(cache.update(db, next, movePatch)).toBe(calculateHash(next))
+        db = next
+
+        const copyPatch = [{ op: 'copy', from: '/right/a', path: '/left/copied' }]
+        next = apply(db, copyPatch)
+        expect(cache.update(db, next, copyPatch)).toBe(calculateHash(next))
+    })
+
+    it('decodes escaped JSON pointer top-level keys', () => {
+        const { keys, touchesRoot } = collectTouchedTopLevelKeys([
+            { op: 'replace', path: '/a~1b/value', value: 2 },
+            { op: 'copy', from: '/x~0y/value', path: '/plain/value' },
+        ])
+        expect(touchesRoot).toBe(false)
+        expect([...keys].sort()).toEqual(['a/b', 'plain', 'x~y'].sort())
+    })
+
+    it('falls back to a full rebuild when the document root is touched', () => {
+        const cache = createPatchHashCache(calculateHash)
+        const db = { a: { n: 1 }, b: { n: 2 } }
+        expect(cache.hash(db)).toBe(calculateHash(db))
+        const next = { replacement: { ok: true } }
+        expect(cache.update(db, next, [{ op: 'replace', path: '', value: next }])).toBe(calculateHash(next))
+    })
+
+    it('does not rehash an untouched large top-level value on a later patch', () => {
+        const largeUntouched = { items: Array.from({ length: 200 }, (_, i) => ({ i, text: `v-${i}` })) }
+        const db = { largeUntouched, touched: { n: 1 }, other: 'x' }
+        let largeHashCalls = 0
+        const countingHash = (value: any) => {
+            if (value === largeUntouched) largeHashCalls++
+            return calculateHash(value)
+        }
+        const cache = createPatchHashCache(countingHash)
+        expect(cache.hash(db)).toBe(calculateHash(db))
+        expect(largeHashCalls).toBe(1)
+
+        const patch = [{ op: 'replace', path: '/touched/n', value: 2 }]
+        const next = apply(db, patch)
+        expect(cache.update(db, next, patch)).toBe(calculateHash(next))
+        expect(largeHashCalls).toBe(1)
+    })
+})


### PR DESCRIPTION
## PR Checklist

- Required Checks
  - [ ] Have you added type definitions?
  - [x] Have you tested your changes?
  - [x] Have you checked that it won't break any existing features?

## Summary

Reduce server-side hash verification work in the Node `/api/patch` path for large databases.

Instead of recursively hashing the entire stripped database on every patch request, this change caches the hash of each top-level database value and recomputes only the top-level keys touched by the JSON Patch.

## Related Issues

None.

## Changes

- Add a compositional database patch hash cache.
- Preserve the exact existing `calculateHash()` result and `expectedHash` protocol.
- Track both `path` and `from` for move/copy operations.
- Decode escaped JSON Pointer keys.
- Re-hash only touched top-level database values after a successful patch.
- Fall back conservatively when the document root is modified.
- Keep non-database patch hashing unchanged.
- Add tests comparing cached hashes against the existing reference `calculateHash()` implementation.

## Impact

Node/self-host users with large databases can avoid recursively hashing unrelated database branches on every `/api/patch` request.

Hash semantics and conflict detection remain unchanged. The cache only changes how the same server hash is calculated.

## Additional Notes

This PR is intentionally independent from the ETag optimization in PR #67 and the selective-clone optimization in PR #69.

It does not change ETag generation, database persistence, JSON Patch application, or cloning behavior.