### PR TITLE
perf: clone only touched DB patch branches

### DIFF
--- a/server/node/patch-selective-clone.cjs
+++ b/server/node/patch-selective-clone.cjs
@@ -1,0 +1,68 @@
+'use strict';
+
+function decodePointerSegment(segment) {
+    return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function collectPatchTopLevelKeys(patch) {
+    const keys = new Set();
+    let touchesRoot = false;
+
+    for (const op of Array.isArray(patch) ? patch : []) {
+        for (const field of ['path', 'from']) {
+            const pointer = op?.[field];
+            if (typeof pointer !== 'string') continue;
+            if (pointer === '') {
+                touchesRoot = true;
+                continue;
+            }
+            if (!pointer.startsWith('/')) {
+                touchesRoot = true;
+                continue;
+            }
+            const nextSlash = pointer.indexOf('/', 1);
+            const rawSegment = nextSlash === -1
+                ? pointer.slice(1)
+                : pointer.slice(1, nextSlash);
+            keys.add(decodePointerSegment(rawSegment));
+        }
+    }
+
+    return { keys, touchesRoot };
+}
+
+function isPlainPatchRoot(database) {
+    return database !== null && typeof database === 'object' && !Array.isArray(database);
+}
+
+function clonePatchSnapshot(database, patch) {
+    if (!isPlainPatchRoot(database)) {
+        return structuredClone(database);
+    }
+
+    const { keys, touchesRoot } = collectPatchTopLevelKeys(patch);
+    if (touchesRoot) {
+        return structuredClone(database);
+    }
+
+    // The root itself must be independent so top-level add/remove/replace ops
+    // cannot mutate the live cache. Untouched nested branches stay shared;
+    // every top-level branch that a patch can mutate is cloned below.
+    const snapshot = { ...database };
+    for (const key of keys) {
+        if (Object.prototype.hasOwnProperty.call(database, key)) {
+            Object.defineProperty(snapshot, key, {
+                value: structuredClone(database[key]),
+                enumerable: true,
+                configurable: true,
+                writable: true,
+            });
+        }
+    }
+    return snapshot;
+}
+
+module.exports = {
+    clonePatchSnapshot,
+    collectPatchTopLevelKeys,
+};

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -33,6 +33,7 @@ const {
 const { createRequestLogs } = require('./request-logs.cjs');
 const { applyPatch } = require('fast-json-patch');
 const { decodeRisuSave, encodeRisuSaveLegacy, calculateHash, normalizeJSON, normalizeForwardHeaders, hasRemoteBlocks } = require('./utils.cjs');
+const { clonePatchSnapshot } = require('./patch-selective-clone.cjs');
 const { spawn, execSync } = require('child_process');
 const os = require('os');
 const { Readable, Transform } = require('stream');
@@ -3810,7 +3811,9 @@ app.post('/api/patch', async (req, res, next) => {
             // length), which rejected every patch. The cache is normalized to
             // plain JSON values at load, so the clone semantics are identical.
             patchStage = 'clone';
-            const snapshot = structuredClone(dbCache[filePath]);
+            const snapshot = decodedKey === 'database/database.bin'
+                ? clonePatchSnapshot(dbCache[filePath], patch)
+                : structuredClone(dbCache[filePath]);
             patchStage = 'apply';
             let result;
             try {

--- a/test/patch-selective-clone.test.ts
+++ b/test/patch-selective-clone.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import selectiveClonePkg from '../server/node/patch-selective-clone.cjs'
+import jsonPatchPkg from 'fast-json-patch'
+
+const { clonePatchSnapshot, collectPatchTopLevelKeys } = selectiveClonePkg as {
+    clonePatchSnapshot: (database: any, patch: any[]) => any
+    collectPatchTopLevelKeys: (patch: any[]) => { keys: Set<string>, touchesRoot: boolean }
+}
+const { applyPatch } = jsonPatchPkg
+
+function apply(base: any, patch: any[]) {
+    const snapshot = clonePatchSnapshot(base, patch)
+    applyPatch(snapshot, patch, true)
+    return snapshot
+}
+
+describe('selective patch snapshot', () => {
+    it('clones only the touched top-level branch for a nested replace', () => {
+        const untouched = { items: Array.from({ length: 200 }, (_, i) => ({ i, text: `v-${i}` })) }
+        const db = { untouched, touched: { nested: { n: 1 } }, other: { ok: true } }
+        const patch = [{ op: 'replace', path: '/touched/nested/n', value: 2 }]
+        const snapshot = clonePatchSnapshot(db, patch)
+
+        expect(snapshot).not.toBe(db)
+        expect(snapshot.touched).not.toBe(db.touched)
+        expect(snapshot.untouched).toBe(untouched)
+        expect(snapshot.other).toBe(db.other)
+
+        applyPatch(snapshot, patch, true)
+        expect(snapshot.touched.nested.n).toBe(2)
+        expect(db.touched.nested.n).toBe(1)
+    })
+
+    it('keeps top-level add/remove operations isolated with only a shallow root copy', () => {
+        const db = { keep: { value: 1 }, removeMe: { value: 2 } }
+        const patch = [
+            { op: 'remove', path: '/removeMe' },
+            { op: 'add', path: '/added', value: { value: 3 } },
+        ]
+        const snapshot = apply(db, patch)
+
+        expect(snapshot.removeMe).toBeUndefined()
+        expect(snapshot.added).toEqual({ value: 3 })
+        expect(db.removeMe).toEqual({ value: 2 })
+        expect((db as any).added).toBeUndefined()
+        expect(snapshot.keep).toBe(db.keep)
+    })
+
+    it('clones both source and destination roots for move/copy patches', () => {
+        const db = {
+            left: { moved: { n: 1 }, copied: { n: 2 } },
+            right: { existing: true },
+            untouched: { stable: true },
+        }
+        const patch = [
+            { op: 'move', from: '/left/moved', path: '/right/moved' },
+            { op: 'copy', from: '/left/copied', path: '/right/copied' },
+        ]
+        const snapshot = clonePatchSnapshot(db, patch)
+
+        expect(snapshot.left).not.toBe(db.left)
+        expect(snapshot.right).not.toBe(db.right)
+        expect(snapshot.untouched).toBe(db.untouched)
+
+        applyPatch(snapshot, patch, true)
+        expect(snapshot.left.moved).toBeUndefined()
+        expect(snapshot.right.moved).toEqual({ n: 1 })
+        expect(snapshot.right.copied).toEqual({ n: 2 })
+        expect(db.left.moved).toEqual({ n: 1 })
+        expect((db.right as any).moved).toBeUndefined()
+    })
+
+    it('preserves the live database when a later patch operation throws', () => {
+        const db = { touched: { n: 1 }, untouched: { value: 9 } }
+        const before = structuredClone(db)
+        const patch = [
+            { op: 'replace', path: '/touched/n', value: 2 },
+            { op: 'remove', path: '/touched/missing' },
+        ]
+        const snapshot = clonePatchSnapshot(db, patch)
+
+        expect(() => applyPatch(snapshot, patch, true)).toThrow()
+        expect(db).toEqual(before)
+    })
+
+    it('falls back to a full clone for a document-root operation', () => {
+        const db = { a: { n: 1 }, b: { n: 2 } }
+        const snapshot = clonePatchSnapshot(db, [{ op: 'replace', path: '', value: { c: 3 } }])
+
+        expect(snapshot).not.toBe(db)
+        expect(snapshot.a).not.toBe(db.a)
+        expect(snapshot.b).not.toBe(db.b)
+    })
+
+    it('falls back to a full clone for an array document root', () => {
+        const db = [{ n: 1 }, { n: 2 }]
+        const snapshot = clonePatchSnapshot(db, [{ op: 'replace', path: '/0/n', value: 3 }])
+
+        expect(snapshot).not.toBe(db)
+        expect(snapshot[0]).not.toBe(db[0])
+        expect(snapshot[1]).not.toBe(db[1])
+    })
+
+    it('decodes escaped JSON pointer root keys and treats invalid pointers conservatively', () => {
+        const decoded = collectPatchTopLevelKeys([
+            { op: 'replace', path: '/a~1b/n', value: 2 },
+            { op: 'move', from: '/x~0y/n', path: '/plain/n' },
+        ])
+        expect(decoded.touchesRoot).toBe(false)
+        expect([...decoded.keys].sort()).toEqual(['a/b', 'plain', 'x~y'].sort())
+
+        const invalid = collectPatchTopLevelKeys([{ op: 'replace', path: 'not-a-pointer', value: 1 }])
+        expect(invalid.touchesRoot).toBe(true)
+    })
+})


### PR DESCRIPTION
Summary

Reduce /api/patch cloning cost for large Node/self-host databases while preserving atomic patch application.
Instead of structuredClone()-ing the entire stripped database for every database patch, this change creates a shallow root snapshot and deep-clones only the top-level branches that the JSON Patch can mutate.

Related Issues

None.

Changes

Add a selective JSON Patch snapshot helper.
Track both path and from for move/copy operations.
Decode escaped JSON Pointer keys.
Clone only touched top-level branches.
Fall back to a full clone for document-root operations or non-object roots.
Keep non-database patch handling unchanged.
Add tests covering nested edits, top-level add/remove, move/copy, failed-patch atomicity, root replacement, and escaped pointers.
Impact
Large Node/self-host databases can avoid deep-cloning unrelated database branches on each patch.
Patch semantics and failure atomicity remain unchanged: the live database cache is not modified unless the full patch applies successfully.

Additional Notes

This PR is intentionally independent from the compositional hash-cache optimization in PR #68 and the ETag optimization in PR #67.
Deeper pluginCustomStorage selective cloning is intentionally excluded and can be reviewed separately.