### PR TITLE
fix: preserve message metadata in Lua setFullChat()

### DIFF
--- a/src/ts/process/scriptings.ts
+++ b/src/ts/process/scriptings.ts
@@ -260,9 +260,11 @@ export async function runScripted(code:string, arg:{
                     return
                 }
                 const realValue = JSON.parse(value)
+                const previousMessages = ScriptingEngineState.chat.message
 
-                ScriptingEngineState.chat.message = realValue.map((v) => {
+                ScriptingEngineState.chat.message = realValue.map((v, index) => {
                     return {
+                        ...previousMessages[index],
                         role: v.role,
                         data: v.data
                     }


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? (No new public types are needed.)
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Preserve existing message metadata by position when Lua calls `setFullChat()`.

## Related Issues

Fixes #70

## Changes

- Keep the previous message array while applying the chat value supplied by Lua.
- Preserve metadata from the existing message at the same position, then overwrite `role` and `data`.
- Messages appended beyond the previous array length continue to contain only `role` and `data`.

## Impact

When a Lua module reads a chat with `getFullChat()` and writes it back with `setFullChat()`, unrelated message metadata is no longer removed. Features and plugins can continue to use message identity, generation details, prompt information, swipe data, and display state.

The repeated summarization seen when using HypaPlus with `🖼️ 보조모델 에셋모듈` is one example of this metadata-loss bug.

The change is limited to `setFullChatMain()` and does not modify model requests, storage formats, or the Lua API.

This treats `setFullChat()` as a positional bulk update. Structural changes in the middle of a chat can use the existing `insertChat()`, `removeChat()`, and `cutChat()` APIs. If a Lua module directly reorders the array, metadata remains positional because the Lua representation does not expose an identity that can reliably match reordered messages.

## Verification

- Confirmed the pre-fix metadata-loss path in persisted chat data.
- Confirmed through request logs that this metadata loss caused repeated summarization when HypaPlus and the asset module were used together.
- `pnpm check` (0 errors; 4 pre-existing accessibility warnings in `DefaultChatScreen.svelte`)
- `pnpm test` (1,141 passed; 3 skipped)
- `pnpm test:compat` (67 passed; 5 skipped)
- `pnpm build` (completed with pre-existing warnings)
