### PR TITLE
feat(server): add lazy asset manifest store and migration

### DIFF
--- a/server/node/assetManifestMigration.cjs
+++ b/server/node/assetManifestMigration.cjs
@@ -1,0 +1,193 @@
+'use strict';
+
+const crypto = require('crypto');
+
+function fallbackOwnerId(prefix, name, index) {
+    return `${prefix}-${crypto.createHash('sha256')
+        .update(`${String(name || '')}\0${index}`)
+        .digest('hex')
+        .slice(0, 24)}`;
+}
+
+function moduleOwnerId(module, index) {
+    return String(module?.id || module?.namespace || fallbackOwnerId('module', module?.name, index));
+}
+
+function characterOwnerId(character, index) {
+    return String(character?.chaId || fallbackOwnerId('character', character?.name, index));
+}
+
+function personaOwnerId(persona, index) {
+    return String(persona?.id || persona?.personaId || fallbackOwnerId('persona', persona?.name, index));
+}
+
+function enrichDescriptor(descriptor, kind, ownerId) {
+    return {
+        ...descriptor,
+        ownerKind: kind,
+        ownerId,
+    };
+}
+
+/**
+ * Move large tuple arrays out of a decoded DB object and into immutable
+ * manifests. Returns a shallow structural copy; the source object and its
+ * arrays are never mutated. Empty arrays stay inline because they cost nothing
+ * and preserve old UI initialization semantics.
+ */
+function stripAssetManifests(dbObj, store, { activate = true } = {}) {
+    if (!dbObj || typeof dbObj !== 'object') return { db: dbObj, migrated: [] };
+    const migrated = [];
+    const out = { ...dbObj };
+
+    if (Array.isArray(dbObj.modules)) {
+        out.modules = dbObj.modules.map((module, index) => {
+            if (!module || !Array.isArray(module.assets) || module.assets.length === 0) return module;
+            const ownerId = moduleOwnerId(module, index);
+            try {
+                const descriptor = enrichDescriptor(
+                    store.putManifest('module', ownerId, module.assets, { activate }),
+                    'module', ownerId,
+                );
+                const next = { ...module, assetManifest: descriptor };
+                delete next.assets;
+                migrated.push(descriptor);
+                return next;
+            } catch (error) {
+                store.recordMigrationFailure('module', ownerId, error);
+                throw error;
+            }
+        });
+    }
+
+    if (Array.isArray(dbObj.characters)) {
+        out.characters = dbObj.characters.map((character, index) => {
+            if (!character || !Array.isArray(character.additionalAssets) || character.additionalAssets.length === 0) {
+                return character;
+            }
+            const ownerId = characterOwnerId(character, index);
+            try {
+                const descriptor = enrichDescriptor(
+                    store.putManifest('character', ownerId, character.additionalAssets, { activate }),
+                    'character', ownerId,
+                );
+                const next = { ...character, additionalAssetManifest: descriptor };
+                delete next.additionalAssets;
+                migrated.push(descriptor);
+                return next;
+            } catch (error) {
+                store.recordMigrationFailure('character', ownerId, error);
+                throw error;
+            }
+        });
+    }
+
+    if (Array.isArray(dbObj.personas)) {
+        out.personas = dbObj.personas.map((persona, index) => {
+            const embedded = persona?.embeddedModule;
+            if (!embedded || !Array.isArray(embedded.assets) || embedded.assets.length === 0) return persona;
+            const ownerId = personaOwnerId(persona, index);
+            try {
+                const descriptor = enrichDescriptor(
+                    store.putManifest('persona-module', ownerId, embedded.assets, { activate }),
+                    'persona-module', ownerId,
+                );
+                const nextEmbedded = { ...embedded, assetManifest: descriptor };
+                delete nextEmbedded.assets;
+                migrated.push(descriptor);
+                return { ...persona, embeddedModule: nextEmbedded };
+            } catch (error) {
+                store.recordMigrationFailure('persona-module', ownerId, error);
+                throw error;
+            }
+        });
+    }
+
+    return { db: out, migrated };
+}
+
+function loadDescriptorItems(store, descriptor) {
+    if (!descriptor?.id) throw new Error('Asset manifest descriptor is missing an id');
+    const verified = store.verifyManifest(descriptor.id);
+    if (!verified.ok) throw new Error(`Asset manifest is unavailable or corrupt: ${descriptor.id}`);
+    if (descriptor.version !== undefined && verified.version !== descriptor.version) {
+        throw new Error(`Asset manifest version mismatch: ${descriptor.id}`);
+    }
+    if (descriptor.count !== undefined && verified.count !== descriptor.count) {
+        throw new Error(`Asset manifest count mismatch: ${descriptor.id}`);
+    }
+    if (descriptor.sha256 && verified.sha256 !== descriptor.sha256) {
+        throw new Error(`Asset manifest hash mismatch: ${descriptor.id}`);
+    }
+    if (descriptor.ownerKind && verified.ownerKind !== descriptor.ownerKind) {
+        throw new Error(`Asset manifest owner kind mismatch: ${descriptor.id}`);
+    }
+    if (descriptor.ownerId && verified.ownerId !== descriptor.ownerId) {
+        throw new Error(`Asset manifest owner id mismatch: ${descriptor.id}`);
+    }
+    return store.loadItems(descriptor.id);
+}
+
+/** Rebuild legacy tuple arrays for disk persistence and RisuAI-compatible export. */
+function hydrateAssetManifests(dbObj, store) {
+    if (!dbObj || typeof dbObj !== 'object') return dbObj;
+    const out = { ...dbObj };
+
+    if (Array.isArray(dbObj.modules)) {
+        out.modules = dbObj.modules.map((module) => {
+            if (!module?.assetManifest) return module;
+            const next = { ...module, assets: loadDescriptorItems(store, module.assetManifest) };
+            delete next.assetManifest;
+            return next;
+        });
+    }
+
+    if (Array.isArray(dbObj.characters)) {
+        out.characters = dbObj.characters.map((character) => {
+            if (!character?.additionalAssetManifest) return character;
+            const next = {
+                ...character,
+                additionalAssets: loadDescriptorItems(store, character.additionalAssetManifest),
+            };
+            delete next.additionalAssetManifest;
+            return next;
+        });
+    }
+
+    if (Array.isArray(dbObj.personas)) {
+        out.personas = dbObj.personas.map((persona) => {
+            const embedded = persona?.embeddedModule;
+            if (!embedded?.assetManifest) return persona;
+            const nextEmbedded = { ...embedded, assets: loadDescriptorItems(store, embedded.assetManifest) };
+            delete nextEmbedded.assetManifest;
+            return { ...persona, embeddedModule: nextEmbedded };
+        });
+    }
+
+    return out;
+}
+
+function assetManifestSummary(dbObj) {
+    const descriptors = [];
+    for (const module of dbObj?.modules || []) if (module?.assetManifest) descriptors.push(module.assetManifest);
+    for (const character of dbObj?.characters || []) {
+        if (character?.additionalAssetManifest) descriptors.push(character.additionalAssetManifest);
+    }
+    for (const persona of dbObj?.personas || []) {
+        if (persona?.embeddedModule?.assetManifest) descriptors.push(persona.embeddedModule.assetManifest);
+    }
+    return {
+        manifests: descriptors.length,
+        items: descriptors.reduce((sum, descriptor) => sum + (Number(descriptor.count) || 0), 0),
+        descriptors,
+    };
+}
+
+module.exports = {
+    stripAssetManifests,
+    hydrateAssetManifests,
+    assetManifestSummary,
+    moduleOwnerId,
+    characterOwnerId,
+    personaOwnerId,
+};

--- a/server/node/assetManifestMigration.test.ts
+++ b/server/node/assetManifestMigration.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3'
+import storePkg from './assetManifestStore.cjs'
+import migrationPkg from './assetManifestMigration.cjs'
+
+const { createAssetManifestStore } = storePkg as any
+const { stripAssetManifests, hydrateAssetManifests, assetManifestSummary } = migrationPkg as any
+
+function freshStore() {
+    return createAssetManifestStore(new Database(':memory:'))
+}
+
+describe('asset manifest migration compatibility layer', () => {
+    it('strips module, character and embedded persona arrays without mutating source', () => {
+        const store = freshStore()
+        const source = {
+            modules: [{ id: 'm1', name: 'Pack', assets: [['m', 'assets/m.png', 'png']] }],
+            characters: [{ chaId: 'c1', name: 'Char', additionalAssets: [['c', 'assets/c.png', 'png']] }],
+            personas: [{ id: 'p1', embeddedModule: { id: 'embedded', assets: [['p', 'assets/p.png', 'png']] } }],
+        }
+
+        const result = stripAssetManifests(source, store)
+        expect(source.modules[0].assets).toHaveLength(1)
+        expect(source.characters[0].additionalAssets).toHaveLength(1)
+        expect(source.personas[0].embeddedModule.assets).toHaveLength(1)
+
+        expect(result.db.modules[0].assets).toBeUndefined()
+        expect(result.db.modules[0].assetManifest).toMatchObject({ ownerKind: 'module', ownerId: 'm1', count: 1 })
+        expect(result.db.characters[0].additionalAssets).toBeUndefined()
+        expect(result.db.characters[0].additionalAssetManifest).toMatchObject({ ownerKind: 'character', ownerId: 'c1' })
+        expect(result.db.personas[0].embeddedModule.assets).toBeUndefined()
+        expect(result.migrated).toHaveLength(3)
+        expect(assetManifestSummary(result.db)).toMatchObject({ manifests: 3, items: 3 })
+    })
+
+    it('hydrates a byte-for-byte JSON-equivalent legacy shape for persistence/export', () => {
+        const store = freshStore()
+        const source = {
+            untouched: { value: true },
+            modules: [{ id: 'm1', name: 'Pack', assets: [['A', 'assets/A.PNG', 'PNG'], ['legacy', 'assets/x']] }],
+            characters: [{ chaId: 'c1', additionalAssets: [['표정', 'assets/c.webp', 'webp']] }],
+            personas: [],
+        }
+
+        const stripped = stripAssetManifests(source, store).db
+        const hydrated = hydrateAssetManifests(stripped, store)
+        expect(hydrated).toEqual(source)
+        expect(stripped.modules[0].assetManifest).toBeDefined()
+    })
+
+    it('does not externalize empty arrays', () => {
+        const store = freshStore()
+        const source = {
+            modules: [{ id: 'm1', assets: [] }],
+            characters: [{ chaId: 'c1', additionalAssets: [] }],
+            personas: [],
+        }
+        const result = stripAssetManifests(source, store)
+        expect(result.db).toEqual(source)
+        expect(result.migrated).toHaveLength(0)
+    })
+
+    it('refuses hydration after manifest corruption instead of dropping assets', () => {
+        const db = new Database(':memory:')
+        const store = createAssetManifestStore(db, { maxCacheBytes: 0 })
+        const source = { modules: [{ id: 'm1', assets: [['a', 'assets/a.png', 'png']] }] }
+        const stripped = stripAssetManifests(source, store).db
+        db.prepare('UPDATE asset_manifests SET content_hash = ?').run('0'.repeat(64))
+        expect(() => hydrateAssetManifests(stripped, store)).toThrow(/unavailable or corrupt/)
+    })
+
+    it('treats a descriptor as authoritative over an accidental inline empty array', () => {
+        const store = freshStore()
+        const source = { modules: [{ id: 'm1', assets: [['safe', 'assets/safe.png', 'png']] }] }
+        const stripped = stripAssetManifests(source, store).db
+        stripped.modules[0].assets = []
+        expect(hydrateAssetManifests(stripped, store)).toEqual(source)
+    })
+
+    it('rejects descriptor owner or version tampering', () => {
+        const store = freshStore()
+        const source = { modules: [{ id: 'm1', assets: [['safe', 'assets/safe.png', 'png']] }] }
+        const stripped = stripAssetManifests(source, store).db
+
+        stripped.modules[0].assetManifest.ownerId = 'another-module'
+        expect(() => hydrateAssetManifests(stripped, store)).toThrow(/owner id mismatch/)
+
+        stripped.modules[0].assetManifest.ownerId = 'm1'
+        stripped.modules[0].assetManifest.version = 999
+        expect(() => hydrateAssetManifests(stripped, store)).toThrow(/version mismatch/)
+    })
+})

--- a/server/node/assetManifestStore.cjs
+++ b/server/node/assetManifestStore.cjs
@@ -1,0 +1,459 @@
+'use strict';
+
+const crypto = require('crypto');
+const zlib = require('zlib');
+
+const MANIFEST_FORMAT_VERSION = 1;
+const OWNER_KINDS = new Set(['module', 'character', 'persona-module']);
+const DEFAULT_CACHE_BYTES = 64 * 1024 * 1024;
+
+function assertOwner(kind, ownerId) {
+    if (!OWNER_KINDS.has(kind)) throw new Error(`Unsupported asset manifest owner kind: ${kind}`);
+    if (typeof ownerId !== 'string' || ownerId.length === 0) throw new Error('Asset manifest owner id is required');
+}
+
+function assertItems(items) {
+    if (!Array.isArray(items)) throw new Error('Asset manifest items must be an array');
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (!Array.isArray(item) || item.length < 2 || item.length > 3) {
+            throw new Error(`Invalid asset tuple at index ${i}`);
+        }
+        if (typeof item[0] !== 'string' || typeof item[1] !== 'string') {
+            throw new Error(`Invalid asset tuple strings at index ${i}`);
+        }
+        if (item.length === 3 && item[2] != null && typeof item[2] !== 'string') {
+            throw new Error(`Invalid asset tuple extension at index ${i}`);
+        }
+    }
+}
+
+function encodeItems(items) {
+    assertItems(items);
+    // JSON is intentional here: tuples contain only strings, and using a stable,
+    // portable representation makes the integrity hash independent of msgpack
+    // library versions. Tuple length/order and every string are preserved.
+    const raw = Buffer.from(JSON.stringify(items), 'utf8');
+    const hash = crypto.createHash('sha256').update(raw).digest('hex');
+    const payload = zlib.deflateRawSync(raw, { level: 3 });
+    return { raw, payload, hash };
+}
+
+function decodeItems(payload, expectedHash) {
+    const raw = zlib.inflateRawSync(payload);
+    const hash = crypto.createHash('sha256').update(raw).digest('hex');
+    if (expectedHash && hash !== expectedHash) {
+        throw new Error(`Asset manifest checksum mismatch: expected ${expectedHash}, got ${hash}`);
+    }
+    const items = JSON.parse(raw.toString('utf8'));
+    assertItems(items);
+    return { items, rawBytes: raw.length, hash };
+}
+
+function manifestIdFor(kind, ownerId, contentHash) {
+    return crypto.createHash('sha256')
+        .update(`${kind}\0${ownerId}\0${contentHash}`)
+        .digest('hex');
+}
+
+function decodeAndValidateRow(row) {
+    if (!row) throw new Error('Asset manifest row is missing');
+    if (row.format_version !== MANIFEST_FORMAT_VERSION) {
+        throw new Error(`Unsupported asset manifest version: ${row.format_version}`);
+    }
+    const expectedId = manifestIdFor(row.owner_kind, row.owner_id, row.content_hash);
+    if (row.manifest_id !== expectedId) {
+        throw new Error(`Asset manifest identity mismatch: ${row.manifest_id}`);
+    }
+    const decoded = decodeItems(row.payload, row.content_hash);
+    if (decoded.items.length !== row.item_count || decoded.rawBytes !== row.raw_bytes) {
+        throw new Error(`Asset manifest metadata mismatch: ${row.manifest_id}`);
+    }
+    return decoded;
+}
+
+function stringDistance(a, b) {
+    if (a === b) return 0;
+    if (!a.length) return b.length;
+    if (!b.length) return a.length;
+    let previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 1; i <= a.length; i++) {
+        const current = [i];
+        for (let j = 1; j <= b.length; j++) {
+            current[j] = Math.min(
+                current[j - 1] + 1,
+                previous[j] + 1,
+                previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+            );
+        }
+        previous = current;
+    }
+    return previous[b.length];
+}
+
+function createAssetManifestStore(db, options = {}) {
+    const maxCacheBytes = Number.isFinite(options.maxCacheBytes)
+        ? Math.max(0, options.maxCacheBytes)
+        : DEFAULT_CACHE_BYTES;
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS asset_manifests (
+        manifest_id   TEXT    PRIMARY KEY,
+        owner_kind    TEXT    NOT NULL,
+        owner_id      TEXT    NOT NULL,
+        format_version INTEGER NOT NULL,
+        item_count    INTEGER NOT NULL,
+        content_hash  TEXT    NOT NULL,
+        raw_bytes     INTEGER NOT NULL,
+        payload       BLOB    NOT NULL,
+        created_at    INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_asset_manifests_owner
+        ON asset_manifests(owner_kind, owner_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS asset_manifest_live (
+        owner_kind   TEXT NOT NULL,
+        owner_id     TEXT NOT NULL,
+        manifest_id  TEXT NOT NULL,
+        updated_at   INTEGER NOT NULL,
+        PRIMARY KEY(owner_kind, owner_id),
+        FOREIGN KEY(manifest_id) REFERENCES asset_manifests(manifest_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS asset_manifest_migration (
+        owner_kind   TEXT NOT NULL,
+        owner_id     TEXT NOT NULL,
+        manifest_id  TEXT,
+        source_hash  TEXT,
+        item_count   INTEGER NOT NULL DEFAULT 0,
+        status       TEXT NOT NULL,
+        error        TEXT,
+        updated_at   INTEGER NOT NULL,
+        PRIMARY KEY(owner_kind, owner_id)
+      );
+    `);
+
+    const stmtManifestGet = db.prepare(`
+      SELECT manifest_id, owner_kind, owner_id, format_version, item_count,
+             content_hash, raw_bytes, payload, created_at
+      FROM asset_manifests WHERE manifest_id = ?
+    `);
+    const stmtManifestInsert = db.prepare(`
+      INSERT OR IGNORE INTO asset_manifests
+        (manifest_id, owner_kind, owner_id, format_version, item_count,
+         content_hash, raw_bytes, payload, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const stmtLiveSet = db.prepare(`
+      INSERT INTO asset_manifest_live(owner_kind, owner_id, manifest_id, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(owner_kind, owner_id) DO UPDATE SET
+        manifest_id = excluded.manifest_id,
+        updated_at = excluded.updated_at
+    `);
+    const stmtLiveGet = db.prepare(`
+      SELECT l.owner_kind, l.owner_id, l.manifest_id, l.updated_at,
+             m.format_version, m.item_count, m.content_hash, m.raw_bytes
+      FROM asset_manifest_live l
+      JOIN asset_manifests m ON m.manifest_id = l.manifest_id
+      WHERE l.owner_kind = ? AND l.owner_id = ?
+    `);
+    const stmtMigrationSet = db.prepare(`
+      INSERT INTO asset_manifest_migration
+        (owner_kind, owner_id, manifest_id, source_hash, item_count, status, error, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(owner_kind, owner_id) DO UPDATE SET
+        manifest_id = excluded.manifest_id,
+        source_hash = excluded.source_hash,
+        item_count = excluded.item_count,
+        status = excluded.status,
+        error = excluded.error,
+        updated_at = excluded.updated_at
+    `);
+    const stmtMigrationList = db.prepare(`
+      SELECT owner_kind, owner_id, manifest_id, source_hash, item_count, status, error, updated_at
+      FROM asset_manifest_migration ORDER BY owner_kind, owner_id
+    `);
+
+    const cache = new Map();
+    let cacheBytes = 0;
+
+    function cacheGet(manifestId) {
+        const found = cache.get(manifestId);
+        if (!found) return null;
+        cache.delete(manifestId);
+        cache.set(manifestId, found);
+        return found.items;
+    }
+
+    function cachePut(manifestId, items, rawBytes) {
+        if (maxCacheBytes <= 0 || rawBytes > maxCacheBytes) return;
+        const previous = cache.get(manifestId);
+        if (previous) cacheBytes -= previous.rawBytes;
+        cache.delete(manifestId);
+        cache.set(manifestId, { items, rawBytes });
+        cacheBytes += rawBytes;
+        while (cacheBytes > maxCacheBytes && cache.size > 0) {
+            const oldestId = cache.keys().next().value;
+            const oldest = cache.get(oldestId);
+            cache.delete(oldestId);
+            cacheBytes -= oldest.rawBytes;
+        }
+    }
+
+    function loadItems(manifestId) {
+        const cached = cacheGet(manifestId);
+        if (cached) return cached;
+        const row = stmtManifestGet.get(manifestId);
+        if (!row) return null;
+        const decoded = decodeAndValidateRow(row);
+        cachePut(manifestId, decoded.items, decoded.rawBytes);
+        return decoded.items;
+    }
+
+    function descriptorForRow(row) {
+        if (!row) return null;
+        return {
+            id: row.manifest_id,
+            version: row.format_version,
+            count: row.item_count,
+            sha256: row.content_hash,
+        };
+    }
+
+    const putTx = db.transaction((kind, ownerId, items, activate) => {
+        assertOwner(kind, ownerId);
+        const encoded = encodeItems(items);
+        const manifestId = manifestIdFor(kind, ownerId, encoded.hash);
+        const now = Date.now();
+        stmtManifestInsert.run(
+            manifestId, kind, ownerId, MANIFEST_FORMAT_VERSION, items.length,
+            encoded.hash, encoded.raw.length, encoded.payload, now,
+        );
+        // INSERT OR IGNORE makes repeated writes cheap, but the persisted row
+        // still has to pass integrity checks before it can become live. This
+        // prevents an existing damaged row from being re-activated while a
+        // warm cache temporarily hides its corrupt payload.
+        const stored = stmtManifestGet.get(manifestId);
+        const decoded = decodeAndValidateRow(stored);
+        if (stored.owner_kind !== kind || stored.owner_id !== ownerId || stored.content_hash !== encoded.hash) {
+            throw new Error(`Asset manifest owner mismatch: ${manifestId}`);
+        }
+        if (activate) stmtLiveSet.run(kind, ownerId, manifestId, now);
+        stmtMigrationSet.run(kind, ownerId, manifestId, encoded.hash, items.length, 'verified', null, now);
+        cachePut(manifestId, decoded.items, decoded.rawBytes);
+        return {
+            id: manifestId,
+            version: MANIFEST_FORMAT_VERSION,
+            count: items.length,
+            sha256: encoded.hash,
+        };
+    });
+
+    function putManifest(kind, ownerId, items, { activate = true } = {}) {
+        return putTx(kind, ownerId, items, activate);
+    }
+
+    function getLiveDescriptor(kind, ownerId) {
+        assertOwner(kind, ownerId);
+        const row = stmtLiveGet.get(kind, ownerId);
+        if (row && row.format_version !== MANIFEST_FORMAT_VERSION) {
+            throw new Error(`Unsupported asset manifest version: ${row.format_version}`);
+        }
+        return descriptorForRow(row);
+    }
+
+    function getItemsByOwner(kind, ownerId) {
+        const descriptor = getLiveDescriptor(kind, ownerId);
+        return descriptor ? loadItems(descriptor.id) : null;
+    }
+
+    function getPage(manifestId, { offset = 0, limit = 100, search = '' } = {}) {
+        const items = loadItems(manifestId);
+        if (!items) return null;
+        const safeOffset = Math.max(0, Math.trunc(Number(offset) || 0));
+        const safeLimit = Math.min(500, Math.max(1, Math.trunc(Number(limit) || 100)));
+        const query = String(search || '').toLocaleLowerCase();
+        const filtered = query
+            ? items.filter((item) => item[0].toLocaleLowerCase().includes(query))
+            : items;
+        return {
+            total: filtered.length,
+            offset: safeOffset,
+            limit: safeLimit,
+            items: filtered.slice(safeOffset, safeOffset + safeLimit),
+        };
+    }
+
+    function resolveNames(owners, names) {
+        const wanted = new Set((names || []).map((name) => String(name).toLocaleLowerCase()));
+        // Asset names are imported data. A null-prototype result keeps names
+        // such as "__proto__" and "constructor" as ordinary lookup keys.
+        const resolved = Object.create(null);
+        if (wanted.size === 0) return resolved;
+        const loadedOwners = [];
+        for (const owner of owners || []) {
+            if (!owner) continue;
+            const descriptor = owner.manifestId
+                ? { id: owner.manifestId }
+                : getLiveDescriptor(owner.kind, owner.ownerId);
+            if (!descriptor) continue;
+            const items = loadItems(descriptor.id);
+            if (!items) continue;
+            loadedOwners.push(items);
+            for (const item of items) {
+                const key = item[0].toLocaleLowerCase();
+                if (wanted.has(key) && !Object.hasOwn(resolved, key)) resolved[key] = item[1];
+            }
+            if (Object.keys(resolved).length >= wanted.size) break;
+        }
+        // Preserve the legacy fuzzy fallback without sending every manifest
+        // name to the browser. It is only evaluated for exact misses.
+        for (const name of wanted) {
+            if (Object.hasOwn(resolved, name) || name.length < 3) continue;
+            const dot = name.lastIndexOf('.');
+            const prefix = dot > 0 ? name.slice(0, dot) : '';
+            let bestDistance = Number.POSITIVE_INFINITY;
+            let bestPath = '';
+            for (const items of loadedOwners) {
+                for (const item of items) {
+                    const candidate = item[0].toLocaleLowerCase();
+                    if (!candidate.startsWith(prefix)) continue;
+                    const distance = stringDistance(name, candidate);
+                    if (distance < bestDistance) {
+                        bestDistance = distance;
+                        bestPath = item[1];
+                    }
+                }
+            }
+            // A nearest neighbour is not necessarily a useful match. Without
+            // a distance ceiling an unrelated missing name can silently turn
+            // into the first asset in a manifest.
+            const maxDistance = Math.max(1, Math.floor(name.length * 0.35));
+            if (bestPath && bestDistance <= maxDistance) resolved[name] = bestPath;
+        }
+        return resolved;
+    }
+
+    function applyOperations(kind, ownerId, expectedManifestId, operations) {
+        assertOwner(kind, ownerId);
+        if (!Array.isArray(operations) || operations.length === 0 || operations.length > 1000) {
+            throw new Error('Asset manifest operations must contain 1-1000 entries');
+        }
+        const current = getLiveDescriptor(kind, ownerId);
+        if (!current) throw new Error(`Asset manifest owner not found: ${kind}/${ownerId}`);
+        if (expectedManifestId && expectedManifestId !== current.id) {
+            const error = new Error('Asset manifest revision conflict');
+            error.code = 'MANIFEST_CONFLICT';
+            error.current = current;
+            throw error;
+        }
+        const source = loadItems(current.id);
+        const next = source.map((item) => item.slice());
+        for (const operation of operations) {
+            const type = operation?.type;
+            if (type === 'append') {
+                assertItems([operation.item]);
+                next.push(operation.item.slice());
+                continue;
+            }
+            const index = Math.trunc(Number(operation?.index));
+            if (!Number.isFinite(index) || index < 0 || index >= next.length + (type === 'insert' ? 1 : 0)) {
+                throw new Error(`Invalid asset manifest operation index: ${operation?.index}`);
+            }
+            if (type === 'insert') {
+                assertItems([operation.item]);
+                next.splice(index, 0, operation.item.slice());
+            } else if (type === 'remove') {
+                if (index >= next.length) throw new Error(`Invalid remove index: ${index}`);
+                next.splice(index, 1);
+            } else if (type === 'rename') {
+                if (index >= next.length || typeof operation.name !== 'string') {
+                    throw new Error(`Invalid rename operation at index: ${index}`);
+                }
+                next[index][0] = operation.name;
+            } else if (type === 'replace') {
+                if (index >= next.length) throw new Error(`Invalid replace index: ${index}`);
+                assertItems([operation.item]);
+                next[index] = operation.item.slice();
+            } else {
+                throw new Error(`Unsupported asset manifest operation: ${type}`);
+            }
+        }
+        return putManifest(kind, ownerId, next, { activate: true });
+    }
+
+    function verifyManifest(manifestId) {
+        const row = stmtManifestGet.get(manifestId);
+        if (!row) return { ok: false, error: 'not-found' };
+        try {
+            // Verification deliberately bypasses the LRU so it checks the bytes
+            // currently persisted in SQLite, not an earlier cached decode.
+            const decoded = decodeAndValidateRow(row);
+            return {
+                ok: true,
+                manifestId,
+                version: row.format_version,
+                ownerKind: row.owner_kind,
+                ownerId: row.owner_id,
+                count: decoded.items.length,
+                sha256: row.content_hash,
+                rawBytes: row.raw_bytes,
+            };
+        } catch (error) {
+            return { ok: false, manifestId, error: String(error?.message || error) };
+        }
+    }
+
+    function recordMigrationFailure(kind, ownerId, error) {
+        assertOwner(kind, ownerId);
+        stmtMigrationSet.run(kind, ownerId, null, null, 0, 'failed', String(error?.message || error), Date.now());
+    }
+
+    function listMigrationState() {
+        return stmtMigrationList.all();
+    }
+
+    function stats() {
+        const manifest = db.prepare(`
+          SELECT COUNT(*) AS count, COALESCE(SUM(item_count), 0) AS items,
+                 COALESCE(SUM(raw_bytes), 0) AS raw_bytes,
+                 COALESCE(SUM(LENGTH(payload)), 0) AS stored_bytes
+          FROM asset_manifests
+        `).get();
+        const live = db.prepare(`SELECT COUNT(*) AS count FROM asset_manifest_live`).get();
+        return {
+            manifests: manifest.count,
+            liveManifests: live.count,
+            items: manifest.items,
+            rawBytes: manifest.raw_bytes,
+            storedBytes: manifest.stored_bytes,
+            cacheEntries: cache.size,
+            cacheRawBytes: cacheBytes,
+        };
+    }
+
+    return {
+        putManifest,
+        getLiveDescriptor,
+        getItemsByOwner,
+        loadItems,
+        getPage,
+        resolveNames,
+        applyOperations,
+        verifyManifest,
+        recordMigrationFailure,
+        listMigrationState,
+        stats,
+    };
+}
+
+module.exports = {
+    MANIFEST_FORMAT_VERSION,
+    createAssetManifestStore,
+    encodeItems,
+    decodeItems,
+    manifestIdFor,
+    stringDistance,
+};

--- a/server/node/assetManifestStore.test.ts
+++ b/server/node/assetManifestStore.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3'
+import pkg from './assetManifestStore.cjs'
+
+const { createAssetManifestStore } = pkg as {
+    createAssetManifestStore: (db: any, options?: { maxCacheBytes?: number }) => any
+}
+
+function freshStore(options?: { maxCacheBytes?: number }) {
+    const db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    return { db, store: createAssetManifestStore(db, options) }
+}
+
+describe('asset manifest store', () => {
+    it('preserves tuple order, tuple length, unicode and exact strings', () => {
+        const { store } = freshStore()
+        const items = [
+            ['표정 01.png', 'assets/ABC.png', 'png'],
+            ['legacy-no-ext', 'assets/legacy.webp'],
+            ['CaseSensitive', 'assets/Mixed.Path', ''],
+        ]
+
+        const descriptor = store.putManifest('module', 'module-a', items)
+        expect(descriptor.count).toBe(3)
+        expect(descriptor.sha256).toMatch(/^[a-f0-9]{64}$/)
+        expect(store.loadItems(descriptor.id)).toEqual(items)
+        expect(store.verifyManifest(descriptor.id)).toMatchObject({ ok: true, count: 3 })
+    })
+
+    it('is content-addressed and keeps previous versions immutable', () => {
+        const { db, store } = freshStore()
+        const v1 = store.putManifest('module', 'module-a', [['a', 'assets/a.png', 'png']])
+        const duplicate = store.putManifest('module', 'module-a', [['a', 'assets/a.png', 'png']])
+        const v2 = store.putManifest('module', 'module-a', [
+            ['a', 'assets/a.png', 'png'],
+            ['b', 'assets/b.png', 'png'],
+        ])
+
+        expect(duplicate.id).toBe(v1.id)
+        expect(v2.id).not.toBe(v1.id)
+        expect(store.getLiveDescriptor('module', 'module-a')).toEqual(v2)
+        expect(store.loadItems(v1.id)).toEqual([['a', 'assets/a.png', 'png']])
+        expect(db.prepare('SELECT COUNT(*) AS count FROM asset_manifests').get().count).toBe(2)
+    })
+
+    it('keeps owners independent even when their content is identical', () => {
+        const { store } = freshStore()
+        const items = [['same', 'assets/same.png', 'png']]
+        const moduleManifest = store.putManifest('module', 'same-id', items)
+        const characterManifest = store.putManifest('character', 'same-id', items)
+
+        expect(moduleManifest.id).not.toBe(characterManifest.id)
+        expect(store.getItemsByOwner('module', 'same-id')).toEqual(items)
+        expect(store.getItemsByOwner('character', 'same-id')).toEqual(items)
+    })
+
+    it('pages, searches and resolves names without returning the whole manifest', () => {
+        const { store } = freshStore()
+        const descriptor = store.putManifest('module', 'module-a', [
+            ['Alpha.PNG', 'assets/a.png', 'png'],
+            ['beta.webp', 'assets/b.webp', 'webp'],
+            ['alphabet.gif', 'assets/c.gif', 'gif'],
+        ])
+
+        expect(store.getPage(descriptor.id, { offset: 1, limit: 1 })).toEqual({
+            total: 3,
+            offset: 1,
+            limit: 1,
+            items: [['beta.webp', 'assets/b.webp', 'webp']],
+        })
+        expect(store.getPage(descriptor.id, { search: 'ALPHA', limit: 100 })).toMatchObject({
+            total: 2,
+            items: [
+                ['Alpha.PNG', 'assets/a.png', 'png'],
+                ['alphabet.gif', 'assets/c.gif', 'gif'],
+            ],
+        })
+        expect(store.resolveNames(
+            [{ kind: 'module', ownerId: 'module-a' }],
+            ['alpha.png', 'bet.webp', 'missing'],
+        )).toEqual({
+            'alpha.png': 'assets/a.png',
+            'bet.webp': 'assets/b.webp',
+        })
+    })
+
+    it('treats prototype-like asset names as ordinary resolver keys', () => {
+        const { store } = freshStore()
+        store.putManifest('module', 'module-a', [
+            ['__proto__', 'assets/proto'],
+            ['constructor', 'assets/constructor'],
+        ])
+
+        const result = store.resolveNames(
+            [{ kind: 'module', ownerId: 'module-a' }],
+            ['__proto__', 'constructor'],
+        )
+        expect({ ...result }).toEqual({
+            ['__proto__']: 'assets/proto',
+            constructor: 'assets/constructor',
+        })
+    })
+
+    it('detects corrupted payloads before exposing items', () => {
+        const { db, store } = freshStore({ maxCacheBytes: 0 })
+        const descriptor = store.putManifest('module', 'module-a', [['a', 'assets/a.png', 'png']])
+        db.prepare('UPDATE asset_manifests SET payload = ? WHERE manifest_id = ?')
+            .run(Buffer.from('not-deflate'), descriptor.id)
+
+        expect(store.verifyManifest(descriptor.id)).toMatchObject({ ok: false, manifestId: descriptor.id })
+        expect(() => store.loadItems(descriptor.id)).toThrow()
+    })
+
+    it('bypasses a warm cache when verifying persisted bytes', () => {
+        const { db, store } = freshStore()
+        const descriptor = store.putManifest('module', 'module-a', [['a', 'assets/a.png', 'png']])
+        expect(store.loadItems(descriptor.id)).toHaveLength(1)
+
+        db.prepare('UPDATE asset_manifests SET payload = ? WHERE manifest_id = ?')
+            .run(Buffer.from('not-deflate'), descriptor.id)
+
+        expect(store.verifyManifest(descriptor.id)).toMatchObject({ ok: false, manifestId: descriptor.id })
+    })
+
+    it('never activates an existing corrupt content-addressed row', () => {
+        const { db, store } = freshStore()
+        const oldItems = [['old', 'assets/old.png', 'png']]
+        const old = store.putManifest('module', 'module-a', oldItems)
+        const current = store.putManifest('module', 'module-a', [['current', 'assets/current.png', 'png']])
+        db.prepare('UPDATE asset_manifests SET payload = ? WHERE manifest_id = ?')
+            .run(Buffer.from('not-deflate'), old.id)
+
+        expect(() => store.putManifest('module', 'module-a', oldItems)).toThrow()
+        expect(store.getLiveDescriptor('module', 'module-a')).toEqual(current)
+    })
+
+    it('records resumable per-owner migration state', () => {
+        const { store } = freshStore()
+        store.putManifest('module', 'good', [['a', 'assets/a.png', 'png']])
+        store.recordMigrationFailure('character', 'bad', new Error('broken tuple'))
+
+        expect(store.listMigrationState()).toEqual([
+            expect.objectContaining({ owner_kind: 'character', owner_id: 'bad', status: 'failed' }),
+            expect.objectContaining({ owner_kind: 'module', owner_id: 'good', status: 'verified', item_count: 1 }),
+        ])
+    })
+
+    it('applies bounded copy-on-write edits and rejects stale revisions', () => {
+        const { store } = freshStore()
+        const v1 = store.putManifest('module', 'editable', [
+            ['a', 'assets/a.png', 'png'],
+            ['b', 'assets/b.png', 'png'],
+        ])
+        const v2 = store.applyOperations('module', 'editable', v1.id, [
+            { type: 'rename', index: 0, name: 'renamed' },
+            { type: 'remove', index: 1 },
+            { type: 'append', item: ['c', 'assets/c.webp', 'webp'] },
+        ])
+
+        expect(store.loadItems(v1.id)).toEqual([
+            ['a', 'assets/a.png', 'png'],
+            ['b', 'assets/b.png', 'png'],
+        ])
+        expect(store.loadItems(v2.id)).toEqual([
+            ['renamed', 'assets/a.png', 'png'],
+            ['c', 'assets/c.webp', 'webp'],
+        ])
+        expect(() => store.applyOperations('module', 'editable', v1.id, [
+            { type: 'remove', index: 0 },
+        ])).toThrow(/revision conflict/)
+    })
+})

--- a/test/compat/asset-manifest-roundtrip.test.ts
+++ b/test/compat/asset-manifest-roundtrip.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest'
+import Database from 'better-sqlite3'
+import { decodeBackup } from './helpers/decode.js'
+import { encodeBackup } from './helpers/encode.js'
+
+const utils = require('../../server/node/utils.cjs') as typeof import('../../server/node/utils.cjs')
+const storePkg = require('../../server/node/assetManifestStore.cjs') as any
+const migrationPkg = require('../../server/node/assetManifestMigration.cjs') as any
+
+const { createAssetManifestStore } = storePkg
+const { stripAssetManifests, hydrateAssetManifests } = migrationPkg
+
+function databaseEntry(backup: Buffer) {
+    const entry = decodeBackup(backup).find((candidate) => candidate.name === 'database.risudat')
+    if (!entry) throw new Error('database.risudat is missing')
+    return entry
+}
+
+describe('asset manifest RisuAI compatibility', () => {
+    test('imports an upstream backup and exports the exact legacy asset-array shape', async () => {
+        const source = {
+            apiType: 'openai',
+            modules: [{
+                id: 'module-1',
+                name: 'Asset pack',
+                assets: [
+                    ['표정.png', 'assets/module-image', 'png'],
+                    ['legacy-no-extension', 'assets/module-legacy'],
+                ],
+            }],
+            characters: [{
+                chaId: 'character-1',
+                name: 'Character',
+                chats: [],
+                additionalAssets: [['pose.webp', 'assets/character-pose', 'webp']],
+            }],
+            personas: [{
+                id: 'persona-1',
+                name: 'Persona',
+                embeddedModule: {
+                    assets: [['persona.gif', 'assets/persona-image', 'gif']],
+                },
+            }],
+        }
+        const assetBytes = Buffer.from('binary-asset-must-stay-untouched')
+        const upstreamBackup = encodeBackup([
+            { name: 'database.risudat', data: Buffer.from(utils.encodeRisuSaveLegacy(source)) },
+            { name: Buffer.from('module-image').toString('hex'), data: assetBytes },
+        ])
+
+        const imported = await utils.decodeRisuSave(databaseEntry(upstreamBackup).data)
+        const sqlite = new Database(':memory:')
+        const store = createAssetManifestStore(sqlite)
+        const stripped = stripAssetManifests(imported, store).db
+
+        expect(stripped.modules[0].assets).toBeUndefined()
+        expect(stripped.characters[0].additionalAssets).toBeUndefined()
+        expect(stripped.personas[0].embeddedModule.assets).toBeUndefined()
+
+        const legacy = hydrateAssetManifests(stripped, store)
+        const exportedBackup = encodeBackup([
+            { name: 'database.risudat', data: Buffer.from(utils.encodeRisuSaveLegacy(legacy)) },
+            { name: Buffer.from('module-image').toString('hex'), data: assetBytes },
+        ])
+        const reimportedByRisuAI = await utils.decodeRisuSave(databaseEntry(exportedBackup).data)
+
+        expect(reimportedByRisuAI).toEqual(source)
+        expect(decodeBackup(exportedBackup).find((entry) => entry.name !== 'database.risudat')?.data)
+            .toEqual(assetBytes)
+        sqlite.close()
+    })
+})


### PR DESCRIPTION
## PR Checklist - Required Checks

- [ ] Have you added type definitions? (N/A: this PR adds isolated CommonJS server modules with runtime validation; no public TypeScript API is introduced.)
- [x] Have you tested your changes?
- [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following: (N/A: no model/provider behavior is changed.)
- [x] Have you understood what the code does?
- [x] Have you cleaned up any unnecessary or redundant code?
- [x] Is it not a huge change? (Scoped to Issue #66 phase 1: five isolated files; runtime/API/client wiring is intentionally deferred.)

## Summary

Issue #66에서 요청하신 1단계인 **server manifest store and migration** 기반을 추가합니다.

- 대용량 에셋 배열을 content-addressed SQLite manifest로 외부화
- owner별 live revision과 migration 상태 기록
- LRU 기반 지연 조회, 페이지 조회, 검색, 부분 수정(COW) 지원
- 기존 저장 구조와 백업 형식을 유지하기 위한 strip/hydrate 변환 추가
- 이번 PR에서는 런타임 라우트와 클라이언트 연결을 하지 않아 기존 동작은 바뀌지 않습니다

## Related Issues

Related to #66

This is phase 1 of the maintainer-requested sequence, based on current `develop` including the prerequisite server-side asset sweep work.

## Changes

- `asset_manifests`, `asset_manifest_live`, `asset_manifest_migration` 저장소 추가
- module `assets`, character `additionalAssets`, persona embedded module `assets` 변환 지원
- immutable manifest ID(SHA-256), 압축 데이터 및 메타데이터 검증
- 디스크에 저장된 row를 다시 검증한 뒤에만 live pointer를 활성화
- 손상/변조된 manifest 및 descriptor는 fail-closed 처리
- 충돌 감지를 포함한 copy-on-write 편집 API
- `__proto__`, `constructor` 같은 에셋 이름도 안전하게 resolve
- 원본 객체를 변경하지 않고, 빈 배열은 기존 형식 그대로 유지
- hydrate 시 기존 upstream 저장/내보내기 구조를 정확히 복구

## Compatibility verification

자동화 테스트에서 다음 왕복 경로를 검증했습니다.

1. upstream 형식 `.bin` 백업 생성 및 import
2. 에셋 배열을 manifest로 외부화
3. legacy 구조로 hydrate하여 export
4. 다시 import한 뒤 원본 데이터 구조와 에셋 바이트의 완전 일치 확인

현재 사용 중인 실제 저장소에도 읽기 전용으로 검증했습니다.

- source `database.bin`: 284,666,378 bytes
- manifest owners: 334
- asset references: 473,246
- manifest verification failures: 0
- owner round-trip mismatches: 0
- reverse migration to upstream shape: exact match
- stripped `database.bin`: 231,322,868 bytes

## Tests

- server tests: **121 passed**
- compatibility tests: **68 passed, 5 skipped**
- manifest/migration targeted tests: **17 passed**
- main Vitest suite: **69/70 files passed on the default 5s timeout**; the remaining existing inlay property-test file passed **26/26** when rerun with a 20s timeout
- `svelte-check`: **0 errors** (4 pre-existing accessibility warnings)
- production build: **passed**
- `git diff --check`: **passed**

## Impact

현재 런타임에는 연결하지 않은 기반 PR이므로 사용자 동작과 저장 형식에는 즉시 영향이 없습니다. 다음 PR에서 lazy asset API를 연결할 수 있도록 저장소와 호환 변환 경계를 먼저 고정합니다.

Plugin storage snapshot/value, client lazy API, orphan cleanup scanner 확장은 후속 PR로 분리합니다. NAI V5 관련 변경도 이 PR에 포함하지 않습니다.

## Additional Notes

매니페스트 row의 실제 압축 바이트와 메타데이터를 live 활성화 전에 검증하도록 했습니다. 캐시에 정상 데이터가 남아 있더라도 디스크 row가 손상된 경우 재활성화되지 않습니다.
