### PR TITLE
fix: prevent chat scroll jumps while inlays load

### DIFF
--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -29,6 +29,7 @@ import { isMobile } from 'src/ts/platform'
     import MainMenu from '../UI/MainMenu.svelte';
     import AssetInput from './AssetInput.svelte';
     import { scrollWithinContainer } from './scrollWithin';
+    import { preserveChatScrollAnchor, suspendChatScrollAnchor } from './chatScrollAnchor';
     import { aiLawApplies, chatFoldedState, chatFoldedStateMessageIndex, downloadFile } from 'src/ts/globalApi.svelte';
     import { runTrigger } from 'src/ts/process/triggers';
     import { v4 } from 'uuid';
@@ -256,6 +257,10 @@ import { isMobile } from 'src/ts/platform'
     async function scrollToMessage(index: number){
         // Forces the loading of past messages not rendered on the screen
         isScrollingToMessage = true
+        const chatContainer = document.querySelector('.default-chat-screen') as HTMLElement | null;
+        const resumeScrollAnchor = chatContainer
+            ? suspendChatScrollAnchor(chatContainer)
+            : () => {}
         try {
             const totalMessages = currentChat.length
             const neededLoadPages = totalMessages - index + 5
@@ -273,7 +278,6 @@ import { isMobile } from 'src/ts/platform'
                 await sleep(100)
             }
 
-            const chatContainer = document.querySelector('.default-chat-screen') as HTMLElement | null;
             const preIndex = Math.max(0, index - 3)
             const preElement = document.querySelector(`[data-chat-index="${preIndex}"]`)
             // Scroll within the chat container only — raw scrollIntoView climbs to
@@ -316,6 +320,7 @@ import { isMobile } from 'src/ts/platform'
                 }, 2000)
             }
         } finally {
+            resumeScrollAnchor()
             isScrollingToMessage = false
         }
     }
@@ -1265,6 +1270,7 @@ import { isMobile } from 'src/ts/platform'
              resizes, and the sticky composer inside this col-reverse scroller gets misanchored
              (bar floats up with a gap below). PWA/standalone has no URL bar, hence unaffected. -->
         <div class="h-full w-full flex flex-col-reverse overflow-y-auto overscroll-y-contain relative default-chat-screen"
+            use:preserveChatScrollAnchor
             class:nodeonly-standard={DBState.db.theme === ''}
             class:no-chat-width-wide={DBState.db.theme === '' && DBState.db.nodeOnlyStandardChatWidth === 'wide'}
             class:no-chat-width-full={DBState.db.theme === '' && DBState.db.nodeOnlyStandardChatWidth === 'full'}

--- a/src/lib/ChatScreens/chatScrollAnchor.test.ts
+++ b/src/lib/ChatScreens/chatScrollAnchor.test.ts
@@ -1,0 +1,399 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+    captureChatScrollAnchor,
+    preserveChatScrollAnchor,
+    restoreChatScrollAnchor,
+    suspendChatScrollAnchor,
+} from './chatScrollAnchor'
+
+type RectState = { bottom: number; top: number }
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+function createGeometryFixture(options: {
+    messages: Array<{ chatId?: string; chatIndex: string; rect: RectState }>
+    scrollTop: number
+}) {
+    const container = document.createElement('div')
+    let currentScrollTop = options.scrollTop
+    let currentScrollHeight = 4000
+    const rects = new Map<HTMLElement, RectState>()
+
+    Object.defineProperty(container, 'scrollTop', {
+        configurable: true,
+        get: () => currentScrollTop,
+        set: (next: number) => {
+            const delta = next - currentScrollTop
+            currentScrollTop = next
+            for (const rect of rects.values()) {
+                rect.top -= delta
+                rect.bottom -= delta
+            }
+        },
+    })
+    Object.defineProperty(container, 'scrollHeight', {
+        configurable: true,
+        get: () => currentScrollHeight,
+    })
+    container.getBoundingClientRect = () => ({
+        bottom: 500,
+        height: 500,
+        left: 0,
+        right: 600,
+        top: 0,
+        width: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    })
+
+    const messages = options.messages.map(({ chatId, chatIndex, rect }) => {
+        const element = document.createElement('div')
+        element.dataset.chatIndex = chatIndex
+        if (chatId) element.dataset.chatId = chatId
+        const state = { ...rect }
+        rects.set(element, state)
+        element.getBoundingClientRect = () => ({
+            bottom: state.bottom,
+            height: state.bottom - state.top,
+            left: 0,
+            right: 600,
+            top: state.top,
+            width: 600,
+            x: 0,
+            y: state.top,
+            toJSON: () => ({}),
+        })
+        container.appendChild(element)
+        return element
+    })
+
+    return {
+        container,
+        messages,
+        rects,
+        setScrollHeight: (height: number) => { currentScrollHeight = height },
+    }
+}
+
+function installObserverHarness() {
+    let resizeCallback: ResizeObserverCallback = () => {}
+    let mutationCallback: MutationCallback = () => {}
+    let nextFrameId = 1
+    const frames = new Map<number, FrameRequestCallback>()
+    const observe = vi.fn()
+    const unobserve = vi.fn()
+
+    class ResizeObserverMock {
+        constructor(callback: ResizeObserverCallback) {
+            resizeCallback = callback
+        }
+        disconnect() {}
+        observe = observe
+        unobserve = unobserve
+    }
+    class MutationObserverMock {
+        constructor(callback: MutationCallback) {
+            mutationCallback = callback
+        }
+        disconnect() {}
+        observe() {}
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    vi.stubGlobal('MutationObserver', MutationObserverMock)
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        const id = nextFrameId++
+        frames.set(id, callback)
+        return id
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => frames.delete(id))
+
+    return {
+        fireMutation(records: MutationRecord[]) {
+            mutationCallback(records, {} as MutationObserver)
+        },
+        fireResize(elements: HTMLElement[]) {
+            resizeCallback(
+                elements.map((target) => ({ target }) as unknown as ResizeObserverEntry),
+                {} as ResizeObserver,
+            )
+        },
+        flushFrames() {
+            const pending = Array.from(frames.values())
+            frames.clear()
+            for (const frame of pending) frame(0)
+        },
+        observe,
+        unobserve,
+    }
+}
+
+describe('chat scroll anchoring', () => {
+    test('captures the topmost visible message while reading older chat', () => {
+        const { container } = createGeometryFixture({
+            scrollTop: -900,
+            messages: [
+                { chatIndex: '12', rect: { top: 260, bottom: 460 } },
+                { chatIndex: '11', rect: { top: -140, bottom: 260 } },
+            ],
+        })
+
+        expect(captureChatScrollAnchor(container)).toEqual({
+            atLatest: false,
+            chatId: null,
+            chatIndex: '11',
+            top: -140,
+        })
+    })
+
+    test('restores a remounted message by stable chat id', () => {
+        const { container, messages, rects } = createGeometryFixture({
+            scrollTop: -900,
+            messages: [
+                { chatId: 'stable-id', chatIndex: '11', rect: { top: -140, bottom: 260 } },
+            ],
+        })
+        const snapshot = captureChatScrollAnchor(container)
+        const oldMessage = messages[0]
+
+        const replacement = document.createElement('div')
+        replacement.dataset.chatId = 'stable-id'
+        replacement.dataset.chatIndex = '12'
+        const replacementRect = { top: 369, bottom: 769 }
+        rects.set(replacement, replacementRect)
+        replacement.getBoundingClientRect = () => ({
+            bottom: replacementRect.bottom,
+            height: replacementRect.bottom - replacementRect.top,
+            left: 0,
+            right: 600,
+            top: replacementRect.top,
+            width: 600,
+            x: 0,
+            y: replacementRect.top,
+            toJSON: () => ({}),
+        })
+        oldMessage.replaceWith(replacement)
+        rects.delete(oldMessage)
+
+        restoreChatScrollAnchor(container, snapshot)
+
+        expect(container.scrollTop).toBe(-391)
+        expect(replacement.getBoundingClientRect().top).toBe(-140)
+    })
+
+    test('does not double-correct when native anchoring already preserved the message', () => {
+        const { container } = createGeometryFixture({
+            scrollTop: -900,
+            messages: [{ chatIndex: '11', rect: { top: -140, bottom: 260 } }],
+        })
+        const snapshot = captureChatScrollAnchor(container)
+
+        restoreChatScrollAnchor(container, snapshot)
+
+        expect(container.scrollTop).toBe(-900)
+    })
+
+    test('pins the latest view to zero after existing-message growth', () => {
+        const { container } = createGeometryFixture({
+            scrollTop: 0,
+            messages: [{ chatIndex: '20', rect: { top: 120, bottom: 480 } }],
+        })
+        const snapshot = captureChatScrollAnchor(container)
+
+        container.scrollTop = -420
+        restoreChatScrollAnchor(container, snapshot)
+
+        expect(container.scrollTop).toBe(0)
+    })
+
+    test('uses the first resize delivery as a baseline instead of snapping a new user scroll', () => {
+        const observers = installObserverHarness()
+
+        const { container, messages } = createGeometryFixture({
+            scrollTop: 0,
+            messages: [{ chatIndex: '11', rect: { top: -800, bottom: -600 } }],
+        })
+        const controller = preserveChatScrollAnchor(container)
+
+        observers.fireResize([messages[0]])
+        container.scrollTop = -900
+        container.dispatchEvent(new Event('scroll'))
+        observers.flushFrames()
+
+        expect(container.scrollTop).toBe(-900)
+        controller.destroy()
+    })
+
+    test('restores the visible message when another message changes height', () => {
+        const observers = installObserverHarness()
+        const { container, messages, rects, setScrollHeight } = createGeometryFixture({
+            scrollTop: -900,
+            messages: [
+                { chatId: 'stable-id', chatIndex: '11', rect: { top: -140, bottom: 260 } },
+                { chatId: 'other-id', chatIndex: '12', rect: { top: 260, bottom: 460 } },
+            ],
+        })
+        const controller = preserveChatScrollAnchor(container)
+        const anchorRect = rects.get(messages[0])!
+        const otherRect = rects.get(messages[1])!
+
+        anchorRect.top += 180
+        anchorRect.bottom += 180
+        otherRect.bottom += 200
+        setScrollHeight(4200)
+        observers.fireResize([messages[1]])
+        observers.flushFrames()
+
+        expect(messages[0].getBoundingClientRect().top).toBe(-140)
+        controller.destroy()
+    })
+
+    test('keeps a user wheel scroll made while a layout correction is pending', () => {
+        const observers = installObserverHarness()
+        const { container, messages, rects, setScrollHeight } = createGeometryFixture({
+            scrollTop: 0,
+            messages: [{ chatId: 'latest', chatIndex: '20', rect: { top: 120, bottom: 480 } }],
+        })
+        const controller = preserveChatScrollAnchor(container)
+        const rect = rects.get(messages[0])!
+
+        rect.bottom += 200
+        setScrollHeight(4200)
+        observers.fireResize([messages[0]])
+        container.dispatchEvent(new WheelEvent('wheel', { deltaY: -200 }))
+        container.scrollTop = -900
+        container.dispatchEvent(new Event('scroll'))
+        observers.flushFrames()
+
+        expect(container.scrollTop).toBe(-900)
+        controller.destroy()
+    })
+
+    test('tracks a stable message through remount and delayed image growth', () => {
+        const observers = installObserverHarness()
+        const { container, messages, rects, setScrollHeight } = createGeometryFixture({
+            scrollTop: -900,
+            messages: [{ chatId: 'stable-id', chatIndex: '11', rect: { top: -140, bottom: 260 } }],
+        })
+        const controller = preserveChatScrollAnchor(container)
+        const oldMessage = messages[0]
+        const replacement = document.createElement('div')
+        replacement.dataset.chatId = 'stable-id'
+        replacement.dataset.chatIndex = '12'
+        const replacementRect = { top: 369, bottom: 769 }
+        rects.set(replacement, replacementRect)
+        replacement.getBoundingClientRect = () => ({
+            bottom: replacementRect.bottom,
+            height: replacementRect.bottom - replacementRect.top,
+            left: 0,
+            right: 600,
+            top: replacementRect.top,
+            width: 600,
+            x: 0,
+            y: replacementRect.top,
+            toJSON: () => ({}),
+        })
+        const readingMarker = document.createElement('span')
+        const readingMarkerRect = { top: 700, bottom: 720 }
+        rects.set(readingMarker, readingMarkerRect)
+        readingMarker.getBoundingClientRect = () => ({
+            bottom: readingMarkerRect.bottom,
+            height: readingMarkerRect.bottom - readingMarkerRect.top,
+            left: 0,
+            right: 600,
+            top: readingMarkerRect.top,
+            width: 600,
+            x: 0,
+            y: readingMarkerRect.top,
+            toJSON: () => ({}),
+        })
+        replacement.appendChild(readingMarker)
+        oldMessage.replaceWith(replacement)
+        rects.delete(oldMessage)
+
+        observers.fireMutation([{
+            addedNodes: [replacement],
+            removedNodes: [oldMessage],
+            target: container,
+        } as unknown as MutationRecord])
+        observers.flushFrames()
+
+        expect(replacement.getBoundingClientRect().top).toBe(-140)
+        expect(observers.unobserve).toHaveBeenCalledWith(oldMessage)
+        expect(observers.observe).toHaveBeenCalledWith(replacement)
+
+        const markerTopBeforeGrowth = readingMarker.getBoundingClientRect().top
+        replacementRect.top -= 300
+        setScrollHeight(4710)
+        observers.fireResize([replacement])
+        observers.flushFrames()
+
+        expect(readingMarker.getBoundingClientRect().top).toBe(markerTopBeforeGrowth)
+        controller.destroy()
+    })
+
+    test('accepts native anchoring when scroll fires before current-message resize', () => {
+        const observers = installObserverHarness()
+        const { container, messages, rects, setScrollHeight } = createGeometryFixture({
+            scrollTop: -900,
+            messages: [{ chatId: 'stable-id', chatIndex: '11', rect: { top: -140, bottom: 260 } }],
+        })
+        const message = messages[0]
+        const messageRect = rects.get(message)!
+        const marker = document.createElement('span')
+        const markerRect = { top: 100, bottom: 120 }
+        rects.set(marker, markerRect)
+        marker.getBoundingClientRect = () => ({
+            bottom: markerRect.bottom,
+            height: markerRect.bottom - markerRect.top,
+            left: 0,
+            right: 600,
+            top: markerRect.top,
+            width: 600,
+            x: 0,
+            y: markerRect.top,
+            toJSON: () => ({}),
+        })
+        message.appendChild(marker)
+        const controller = preserveChatScrollAnchor(container)
+
+        // Content below the marker grows. Reverse layout first moves the
+        // message/marker up, then native anchoring adjusts scrollTop so the
+        // marker returns to its original visual position before RO fires.
+        messageRect.top -= 300
+        markerRect.top -= 300
+        markerRect.bottom -= 300
+        setScrollHeight(4300)
+        container.scrollTop -= 300
+        container.dispatchEvent(new Event('scroll'))
+        observers.fireResize([message])
+        observers.flushFrames()
+
+        expect(container.scrollTop).toBe(-1200)
+        expect(marker.getBoundingClientRect().top).toBe(100)
+        controller.destroy()
+    })
+
+    test('rebases instead of restoring an old anchor after suspended navigation', () => {
+        const observers = installObserverHarness()
+        const { container } = createGeometryFixture({
+            scrollTop: 0,
+            messages: [{ chatId: 'latest', chatIndex: '20', rect: { top: 120, bottom: 480 } }],
+        })
+        const controller = preserveChatScrollAnchor(container)
+        const resume = suspendChatScrollAnchor(container)
+
+        container.scrollTop = -900
+        container.dispatchEvent(new Event('scroll'))
+        resume()
+        observers.flushFrames()
+
+        expect(container.scrollTop).toBe(-900)
+        controller.destroy()
+    })
+})

--- a/src/lib/ChatScreens/chatScrollAnchor.ts
+++ b/src/lib/ChatScreens/chatScrollAnchor.ts
@@ -1,0 +1,351 @@
+const CHAT_MESSAGE_SELECTOR = '[data-chat-index]'
+const POSITION_EPSILON = 0.5
+const LATEST_SCROLL_EPSILON = 2
+const USER_SCROLL_IDLE_MS = 200
+
+type ChatScrollAnchorController = {
+    rebase: () => void
+    suspend: () => () => void
+}
+
+const controllers = new WeakMap<HTMLElement, ChatScrollAnchorController>()
+
+export type ChatScrollAnchorSnapshot =
+    | { atLatest: true }
+    | {
+        atLatest: false
+        chatId: string | null
+        chatIndex: string
+        top: number
+    }
+
+function getChatMessages(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>(CHAT_MESSAGE_SELECTOR))
+}
+
+function containsChatMessage(node: Node): boolean {
+    if (!(node instanceof Element)) return false
+    return node.matches(CHAT_MESSAGE_SELECTOR) || node.querySelector(CHAT_MESSAGE_SELECTOR) !== null
+}
+
+function getRelativeTop(element: HTMLElement, container: HTMLElement): number {
+    return element.getBoundingClientRect().top - container.getBoundingClientRect().top
+}
+
+function findSnapshotElement(
+    container: HTMLElement,
+    snapshot: Exclude<ChatScrollAnchorSnapshot, { atLatest: true }>,
+): HTMLElement | null {
+    const messages = getChatMessages(container)
+    if (snapshot.chatId) {
+        return messages.find((message) => message.dataset.chatId === snapshot.chatId) ?? null
+    }
+    return messages.find((message) => message.dataset.chatIndex === snapshot.chatIndex) ?? null
+}
+
+/**
+ * Capture a stable message rather than scrollHeight. The chat uses
+ * flex-direction: column-reverse, so scrollTop is negative away from the
+ * latest message and scrollHeight deltas alone point in the wrong direction.
+ */
+export function captureChatScrollAnchor(container: HTMLElement): ChatScrollAnchorSnapshot | null {
+    if (container.scrollTop >= -LATEST_SCROLL_EPSILON) {
+        return { atLatest: true }
+    }
+
+    const containerRect = container.getBoundingClientRect()
+    const visibleMessages = getChatMessages(container)
+        .map((element) => ({ element, rect: element.getBoundingClientRect() }))
+        .filter(({ rect }) => rect.bottom > containerRect.top && rect.top < containerRect.bottom)
+        .sort((a, b) => a.rect.top - b.rect.top)
+
+    const anchor = visibleMessages[0]?.element
+    if (!anchor) return null
+
+    return {
+        atLatest: false,
+        chatId: anchor.dataset.chatId || null,
+        chatIndex: anchor.dataset.chatIndex ?? '',
+        top: getRelativeTop(anchor, container),
+    }
+}
+
+/** Restore a previously captured message to the same viewport-relative top. */
+export function restoreChatScrollAnchor(
+    container: HTMLElement,
+    snapshot: ChatScrollAnchorSnapshot | null,
+): ChatScrollAnchorSnapshot | null {
+    if (!snapshot) return captureChatScrollAnchor(container)
+
+    if (!('top' in snapshot)) {
+        if (Math.abs(container.scrollTop) > POSITION_EPSILON) {
+            container.scrollTop = 0
+        }
+        return snapshot
+    }
+
+    const anchor = findSnapshotElement(container, snapshot)
+    if (!anchor) return captureChatScrollAnchor(container)
+
+    const delta = getRelativeTop(anchor, container) - snapshot.top
+    if (Math.abs(delta) > POSITION_EPSILON) {
+        container.scrollTop += delta
+    }
+
+    // Scroll bounds can clamp the correction when messages are removed. In
+    // that case, start from the new visible message instead of repeatedly
+    // applying an impossible delta on every resize notification.
+    if (Math.abs(getRelativeTop(anchor, container) - snapshot.top) > POSITION_EPSILON) {
+        return captureChatScrollAnchor(container)
+    }
+    return snapshot
+}
+
+/** Rebase after an intentional application-driven scroll. */
+export function rebaseChatScrollAnchor(container: HTMLElement) {
+    controllers.get(container)?.rebase()
+}
+
+/**
+ * Suspend layout correction during multi-step navigation. The returned resume
+ * callback is nesting-safe and rebases on the resulting position.
+ */
+export function suspendChatScrollAnchor(container: HTMLElement): () => void {
+    return controllers.get(container)?.suspend() ?? (() => {})
+}
+
+/**
+ * Svelte action that keeps the reading position stable while module HTML and
+ * asynchronously decoded images change existing message heights.
+ */
+export function preserveChatScrollAnchor(container: HTMLElement) {
+    let snapshot = captureChatScrollAnchor(container)
+    let lastScrollHeight = container.scrollHeight
+    let scheduledFrame: number | null = null
+    let resumeFrame: number | null = null
+    let userScrollTimer: ReturnType<typeof setTimeout> | null = null
+    let applyingCorrection = false
+    let deferredLayoutChange = false
+    let layoutChangePending = false
+    let structuralChangePending = false
+    let destroyed = false
+    let suspendDepth = 0
+    let userScrollActive = false
+    const observedMessages = new Set<HTMLElement>()
+    const observedMessageHeights = new Map<HTMLElement, number>()
+
+    const cancelScheduledRestore = () => {
+        if (scheduledFrame !== null) cancelAnimationFrame(scheduledFrame)
+        scheduledFrame = null
+        layoutChangePending = false
+        structuralChangePending = false
+    }
+
+    const rebase = () => {
+        cancelScheduledRestore()
+        deferredLayoutChange = false
+        snapshot = captureChatScrollAnchor(container)
+        lastScrollHeight = container.scrollHeight
+    }
+
+    const armUserScrollIdle = () => {
+        userScrollActive = true
+        if (userScrollTimer !== null) clearTimeout(userScrollTimer)
+        userScrollTimer = setTimeout(() => {
+            userScrollTimer = null
+            userScrollActive = false
+            if (deferredLayoutChange) {
+                deferredLayoutChange = false
+                scheduleRestore()
+            }
+        }, USER_SCROLL_IDLE_MS)
+    }
+
+    const onUserScrollIntent = () => {
+        if (suspendDepth > 0) return
+        armUserScrollIdle()
+        // A wheel/touch/scrollbar gesture owns the next position. Drop any
+        // stale layout correction before the browser applies that gesture.
+        rebase()
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+        // Pointer events on descendants are ordinary chat interactions. A
+        // pointerdown targeting the scroller itself covers scrollbar drags.
+        if (event.target === container) onUserScrollIntent()
+    }
+
+    const onScrollKey = (event: KeyboardEvent) => {
+        if (![' ', 'ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp'].includes(event.key)) return
+        const target = event.target
+        if (target instanceof HTMLElement && (
+            target.isContentEditable
+            || target.matches('input, textarea, select, [role="textbox"]')
+        )) return
+        onUserScrollIntent()
+    }
+
+    const scheduleRestore = () => {
+        if (suspendDepth > 0) return
+        if (userScrollActive) {
+            deferredLayoutChange = true
+            return
+        }
+        layoutChangePending = true
+        if (scheduledFrame !== null) return
+        scheduledFrame = requestAnimationFrame(() => {
+            scheduledFrame = null
+            if (destroyed) return
+
+            applyingCorrection = true
+            snapshot = restoreChatScrollAnchor(container, snapshot)
+            lastScrollHeight = container.scrollHeight
+            applyingCorrection = false
+            layoutChangePending = false
+            structuralChangePending = false
+        })
+    }
+
+    const suspend = () => {
+        suspendDepth += 1
+        cancelScheduledRestore()
+        let resumed = false
+        return () => {
+            if (resumed) return
+            resumed = true
+            suspendDepth = Math.max(0, suspendDepth - 1)
+            if (suspendDepth > 0 || destroyed) return
+            if (resumeFrame !== null) cancelAnimationFrame(resumeFrame)
+            resumeFrame = requestAnimationFrame(() => {
+                resumeFrame = null
+                if (!destroyed && suspendDepth === 0) rebase()
+            })
+        }
+    }
+
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver((entries) => {
+            let sizeChanged = false
+            let changedOutsideAnchor = false
+            const anchorElement = snapshot && 'top' in snapshot
+                ? findSnapshotElement(container, snapshot)
+                : null
+            for (const entry of entries) {
+                const message = entry.target as HTMLElement
+                const height = message.getBoundingClientRect().height
+                const previousHeight = observedMessageHeights.get(message)
+                observedMessageHeights.set(message, height)
+                if (previousHeight !== undefined && Math.abs(height - previousHeight) > POSITION_EPSILON) {
+                    sizeChanged = true
+                    if (message !== anchorElement) changedOutsideAnchor = true
+                }
+            }
+            if (!sizeChanged) return
+
+            // When content inside the currently read message grows, native
+            // anchoring can keep the visible descendant stable even though the
+            // wrapper's top moves. Restoring the wrapper top would introduce a
+            // jump of our own. A whole-message remount already has a pending
+            // MutationObserver correction, so only rebase the stable-root case.
+            if (anchorElement && !changedOutsideAnchor && !structuralChangePending && suspendDepth === 0) {
+                rebase()
+                return
+            }
+            scheduleRestore()
+        })
+
+    const syncObservedMessages = () => {
+        if (!resizeObserver) return
+        const currentMessages = new Set(getChatMessages(container))
+        for (const message of observedMessages) {
+            if (!currentMessages.has(message)) {
+                resizeObserver.unobserve(message)
+                observedMessages.delete(message)
+                observedMessageHeights.delete(message)
+            }
+        }
+        for (const message of currentMessages) {
+            if (!observedMessages.has(message)) {
+                observedMessageHeights.set(message, message.getBoundingClientRect().height)
+                resizeObserver.observe(message)
+                observedMessages.add(message)
+            }
+        }
+    }
+
+    const mutationObserver = typeof MutationObserver === 'undefined'
+        ? null
+        : new MutationObserver((records) => {
+            const messageTreeChanged = records.some((record) => (
+                Array.from(record.addedNodes).some(containsChatMessage)
+                || Array.from(record.removedNodes).some(containsChatMessage)
+            ))
+
+            if (messageTreeChanged) {
+                syncObservedMessages()
+                structuralChangePending = true
+                scheduleRestore()
+                return
+            }
+
+            // ResizeObserver handles internal module/markdown mutations without
+            // rescanning all messages. Retain a fallback for older browsers.
+            if (!resizeObserver && records.some((record) => (
+                record.target instanceof Element
+                && record.target.closest(CHAT_MESSAGE_SELECTOR) !== null
+            ))) scheduleRestore()
+        })
+
+    const onScroll = () => {
+        if (applyingCorrection || suspendDepth > 0) return
+
+        if (userScrollActive) {
+            rebase()
+            armUserScrollIdle()
+            return
+        }
+
+        if (layoutChangePending) return
+
+        // Native scroll anchoring can emit a scroll event before the resize
+        // observer runs. Do not overwrite the pre-layout snapshot in that gap.
+        if (Math.abs(container.scrollHeight - lastScrollHeight) > POSITION_EPSILON) {
+            scheduleRestore()
+            return
+        }
+        snapshot = captureChatScrollAnchor(container)
+    }
+
+    syncObservedMessages()
+    mutationObserver?.observe(container, { childList: true, subtree: true })
+    container.addEventListener('scroll', onScroll, { passive: true })
+    container.addEventListener('pointerdown', onPointerDown, { passive: true })
+    container.addEventListener('touchmove', onUserScrollIntent, { passive: true })
+    container.addEventListener('touchstart', onUserScrollIntent, { passive: true })
+    container.addEventListener('wheel', onUserScrollIntent, { passive: true })
+    window.addEventListener('keydown', onScrollKey, true)
+
+    const controller = { rebase, suspend }
+    controllers.set(container, controller)
+
+    return {
+        destroy() {
+            destroyed = true
+            cancelScheduledRestore()
+            if (resumeFrame !== null) cancelAnimationFrame(resumeFrame)
+            if (userScrollTimer !== null) clearTimeout(userScrollTimer)
+            mutationObserver?.disconnect()
+            resizeObserver?.disconnect()
+            observedMessages.clear()
+            observedMessageHeights.clear()
+            container.removeEventListener('scroll', onScroll)
+            container.removeEventListener('pointerdown', onPointerDown)
+            container.removeEventListener('touchmove', onUserScrollIntent)
+            container.removeEventListener('touchstart', onUserScrollIntent)
+            container.removeEventListener('wheel', onUserScrollIntent)
+            window.removeEventListener('keydown', onScrollKey, true)
+            if (controllers.get(container) === controller) controllers.delete(container)
+        },
+    }
+}

--- a/src/lib/ChatScreens/scrollWithin.ts
+++ b/src/lib/ChatScreens/scrollWithin.ts
@@ -2,15 +2,35 @@
 // bloated (e.g. by sidebar layout leakage) it gets scrolled too, pushing
 // the viewport off body and revealing gray space below. Use this helper
 // to scroll only the given container instead of climbing to the root.
+import { suspendChatScrollAnchor } from './chatScrollAnchor'
+
 export function scrollWithinContainer(
     el: HTMLElement,
     container: HTMLElement,
     options: { block: 'start' | 'end'; behavior: ScrollBehavior }
 ) {
+    const resumeScrollAnchor = suspendChatScrollAnchor(container)
     const elRect = el.getBoundingClientRect()
     const containerRect = container.getBoundingClientRect()
     const offset = options.block === 'start'
         ? elRect.top - containerRect.top
         : elRect.bottom - containerRect.bottom
     container.scrollTo({ top: container.scrollTop + offset, behavior: options.behavior })
+
+    if (options.behavior !== 'smooth') {
+        requestAnimationFrame(resumeScrollAnchor)
+        return
+    }
+
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null
+    let finished = false
+    const finish = () => {
+        if (finished) return
+        finished = true
+        container.removeEventListener('scrollend', finish)
+        if (fallbackTimer !== null) clearTimeout(fallbackTimer)
+        resumeScrollAnchor()
+    }
+    container.addEventListener('scrollend', finish, { once: true })
+    fallbackTimer = setTimeout(finish, 700)
 }

--- a/src/ts/parser/parser.inlayLoading.test.ts
+++ b/src/ts/parser/parser.inlayLoading.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('../stores.svelte', () => ({
+    DBState: {
+        db: {
+            hideAllImages: false,
+            inlayImagePriority: true,
+        },
+    },
+    selectedCharID: { subscribe: () => () => {} },
+    selIdState: { selId: 0 },
+}))
+
+vi.mock('../process/files/inlays', () => ({
+    getInlayInfosBatch: vi.fn(async () => ({})),
+}))
+
+import { parseInlayAssets, resolveInlayPlaceholders } from './parser.svelte'
+import { DBState } from '../stores.svelte'
+
+describe('inlay loading cache', () => {
+    let intersectionCallbacks: IntersectionObserverCallback[]
+    let createdImages: HTMLImageElement[]
+    let createElementSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        DBState.db.hideAllImages = false
+        intersectionCallbacks = []
+        createdImages = []
+
+        class IntersectionObserverMock {
+            constructor(callback: IntersectionObserverCallback) {
+                intersectionCallbacks.push(callback)
+            }
+            disconnect() {}
+            observe() {}
+            takeRecords() { return [] }
+            unobserve() {}
+        }
+        vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+
+        const createElement = document.createElement.bind(document)
+        createElementSpy = vi.spyOn(document, 'createElement').mockImplementation(((tagName: string, options?: ElementCreationOptions) => {
+            const element = createElement(tagName, options)
+            if (tagName.toLowerCase() === 'img') {
+                let assignedSrc = ''
+                Object.defineProperty(element, 'src', {
+                    configurable: true,
+                    get: () => assignedSrc,
+                    set: (value: string) => { assignedSrc = value },
+                })
+                createdImages.push(element as HTMLImageElement)
+            }
+            return element
+        }) as typeof document.createElement)
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        createElementSpy.mockRestore()
+        vi.unstubAllGlobals()
+        document.body.replaceChildren()
+    })
+
+    test('keeps every rerender on a placeholder until one shared image probe is ready', async () => {
+        const id = `loading-${crypto.randomUUID()}`
+        const token = `{{inlayed::${id}}}`
+        const roots = [document.createElement('div'), document.createElement('div')]
+
+        roots[0].innerHTML = parseInlayAssets(token)
+        document.body.appendChild(roots[0])
+        resolveInlayPlaceholders(roots[0])
+        const firstPlaceholder = roots[0].querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[0]([
+            { isIntersecting: true, target: firstPlaceholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+
+        await vi.waitFor(() => expect(createdImages).toHaveLength(1))
+        expect(parseInlayAssets(token)).toContain('data-inlay-id')
+
+        roots[1].innerHTML = parseInlayAssets(token)
+        document.body.appendChild(roots[1])
+        resolveInlayPlaceholders(roots[1])
+        const secondPlaceholder = roots[1].querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[1]([
+            { isIntersecting: true, target: secondPlaceholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+
+        await Promise.resolve()
+        expect(createdImages).toHaveLength(1)
+
+        const probe = createdImages[0]
+        Object.defineProperties(probe, {
+            naturalHeight: { configurable: true, value: 360 },
+            naturalWidth: { configurable: true, value: 1080 },
+        })
+        probe.onload?.(new Event('load'))
+
+        await vi.waitFor(() => {
+            expect(roots[0].querySelector('img')).not.toBeNull()
+            expect(roots[1].querySelector('img')).not.toBeNull()
+        })
+
+        const rendered = parseInlayAssets(token)
+        expect(rendered).toContain('<img')
+        expect(rendered).toContain('width="1080" height="360"')
+        expect(rendered).not.toContain('data-inlay-id')
+    })
+
+    test('shares the image error probe and caches the detected video type', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(null, {
+            headers: { 'content-type': 'video/mp4' },
+            status: 200,
+        })))
+        const id = `video-${crypto.randomUUID()}`
+        const token = `{{inlay::${id}}}`
+        const root = document.createElement('div')
+        root.innerHTML = parseInlayAssets(token)
+        document.body.appendChild(root)
+        resolveInlayPlaceholders(root)
+        const placeholder = root.querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[0]([
+            { isIntersecting: true, target: placeholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+
+        await vi.waitFor(() => expect(createdImages).toHaveLength(1))
+        await createdImages[0].onerror?.(new Event('error'))
+
+        await vi.waitFor(() => expect(root.querySelector('video')).not.toBeNull())
+        expect(fetch).toHaveBeenCalledTimes(1)
+        expect(parseInlayAssets(token)).toContain('<video controls>')
+    })
+
+    test('removes hidden image placeholders without starting a probe', async () => {
+        DBState.db.hideAllImages = true
+        const id = `hidden-${crypto.randomUUID()}`
+        const root = document.createElement('div')
+        root.innerHTML = parseInlayAssets(`{{inlay::${id}}}`)
+        document.body.appendChild(root)
+        resolveInlayPlaceholders(root)
+        const placeholder = root.querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[0]([
+            { isIntersecting: true, target: placeholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+
+        await vi.waitFor(() => expect(root.querySelector('[data-inlay-id]')).toBeNull())
+        expect(createdImages).toHaveLength(0)
+    })
+
+    test('retries a transient probe failure after a short backoff', async () => {
+        vi.useFakeTimers()
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(null, {
+            headers: { 'content-type': 'image/png' },
+            status: 200,
+        })))
+        const id = `retry-${crypto.randomUUID()}`
+        const root = document.createElement('div')
+        root.innerHTML = parseInlayAssets(`{{inlay::${id}}}`)
+        document.body.appendChild(root)
+        resolveInlayPlaceholders(root)
+        const placeholder = root.querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[0]([
+            { isIntersecting: true, target: placeholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+
+        await Promise.resolve()
+        expect(createdImages).toHaveLength(1)
+        await createdImages[0].onerror?.(new Event('error'))
+        await Promise.resolve()
+
+        expect(root.querySelector('[data-inlay-id]')).not.toBeNull()
+        await vi.advanceTimersByTimeAsync(3000)
+        expect(createdImages).toHaveLength(2)
+    })
+
+    test('stops automatic retries after the bounded exponential backoff', async () => {
+        vi.useFakeTimers()
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(null, {
+            headers: { 'content-type': 'image/png' },
+            status: 200,
+        })))
+        const id = `retry-limit-${crypto.randomUUID()}`
+        const root = document.createElement('div')
+        root.innerHTML = parseInlayAssets(`{{inlay::${id}}}`)
+        document.body.appendChild(root)
+        resolveInlayPlaceholders(root)
+        const placeholder = root.querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[0]([
+            { isIntersecting: true, target: placeholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+        await Promise.resolve()
+
+        const retryDelays = [3000, 6000, 12000, 24000, 30000]
+        for (let index = 0; index < retryDelays.length; index++) {
+            await createdImages[index].onerror?.(new Event('error'))
+            await Promise.resolve()
+            await vi.advanceTimersByTimeAsync(retryDelays[index])
+            expect(createdImages).toHaveLength(index + 2)
+        }
+
+        await createdImages[5].onerror?.(new Event('error'))
+        await Promise.resolve()
+        await vi.advanceTimersByTimeAsync(60000)
+
+        expect(createdImages).toHaveLength(6)
+        expect(root.querySelector('[data-missing-inlay-id]')).not.toBeNull()
+    })
+})

--- a/src/ts/parser/parser.svelte.ts
+++ b/src/ts/parser/parser.svelte.ts
@@ -663,12 +663,38 @@ function trimmer(str:string){
     return str.trim().replace(/[_ -.]/g, '')
 }
 
-const blobUrlCache = new Map<string, { url: string; type: string }>()
+type InlayCacheEntry = {
+    height?: number
+    loadPromise?: Promise<InlayCacheEntry>
+    retryAt?: number
+    retryCount?: number
+    status: 'error' | 'loading' | 'ready'
+    type: string
+    url: string
+    width?: number
+}
+
+const blobUrlCache = new Map<string, InlayCacheEntry>()
 const inlayImageExts = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']
+const INLAY_RETRY_DELAY_MS = 3000
+const MAX_INLAY_RETRY_COUNT = 5
 
 /** Build a direct-serve URL for a KV key via /api/asset/ */
 function assetUrl(kvKey: string): string {
     return `/api/asset/${Buffer.from(kvKey, 'utf-8').toString('hex')}`
+}
+
+function getInlayDimensions(entry?: InlayCacheEntry): { height: number, width: number } | null {
+    const height = Math.round(entry?.height ?? 0)
+    const width = Math.round(entry?.width ?? 0)
+    if (height <= 0 || width <= 0) return null
+    return { height, width }
+}
+
+function getInlayImageSizeAttributes(entry?: InlayCacheEntry): string {
+    const dimensions = getInlayDimensions(entry)
+    if (!dimensions) return ''
+    return ` width="${dimensions.width}" height="${dimensions.height}"`
 }
 
 function createMissingInlayPlaceholder(id: string): HTMLDivElement {
@@ -698,8 +724,8 @@ export function parseInlayAssets(data:string){
             let prefix = inlayType !== 'inlay' ? `<div class="risu-inlay-image">` : ''
             let postfix = inlayType !== 'inlay' ? `</div>\n\n` : ''
 
-            let cached = blobUrlCache.get(id)
-            if(!cached){
+            const cached = blobUrlCache.get(id)
+            if(!cached || cached.status !== 'ready'){
                 // If not in memory cache, inject placeholder
                 const placeholder = `${prefix}<div data-inlay-id="${id}" data-inlay-type="${inlayType}" class="risu-inlay-placeholder risu-loading-spinner" style="width: 100%; min-height: 100px; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.1); border-radius: 8px;"></div>${postfix}`
                 data = data.replace(inlay, placeholder)
@@ -714,7 +740,7 @@ export function parseInlayAssets(data:string){
                         data = data.replace(inlay, '')
                         break
                     }
-                    data = data.replace(inlay, `${prefix}<img src="${url}"/>${postfix}`)
+                    data = data.replace(inlay, `${prefix}<img src="${url}"${getInlayImageSizeAttributes(cached)}/>${postfix}`)
                     break
                 case 'video':
                     data = data.replace(inlay, `${prefix}<video controls><source src="${url}" type="video/mp4"></video>${postfix}`)
@@ -728,125 +754,243 @@ export function parseInlayAssets(data:string){
     return data
 }
 
+function createLoadingInlayEntry(
+    id: string,
+    state: Partial<Pick<InlayCacheEntry, 'height' | 'retryCount' | 'width'>> = {},
+): InlayCacheEntry {
+    return {
+        ...state,
+        status: 'loading',
+        type: 'image',
+        url: assetUrl(`inlay/${id}`),
+    }
+}
+
+function createFailedInlayEntry(entry: InlayCacheEntry, retryable: boolean): InlayCacheEntry {
+    const retryCount = (entry.retryCount ?? 0) + 1
+    const retryDelay = Math.min(INLAY_RETRY_DELAY_MS * (2 ** Math.min(retryCount - 1, 4)), 30000)
+    const shouldRetry = retryable && retryCount <= MAX_INLAY_RETRY_COUNT
+    return {
+        height: entry.height,
+        status: 'error',
+        type: 'image',
+        url: entry.url,
+        retryAt: shouldRetry ? Date.now() + retryDelay : undefined,
+        retryCount,
+        width: entry.width,
+    }
+}
+
+/**
+ * Load/probe an asset once per id. A loading entry is deliberately not a
+ * renderable cache hit: LightBoard can remount the same message before this
+ * promise settles, and that remount must keep its placeholder in-flow.
+ */
+function ensureInlayLoaded(id: string, entry: InlayCacheEntry): Promise<InlayCacheEntry> {
+    if (entry.status !== 'loading' || entry.type !== 'image') return Promise.resolve(entry)
+    if (entry.loadPromise) return entry.loadPromise
+
+    const loadPromise = new Promise<InlayCacheEntry>((resolve) => {
+        const probe = document.createElement('img')
+        let settled = false
+
+        const settle = (result: InlayCacheEntry) => {
+            if (settled) return
+            settled = true
+            probe.onload = null
+            probe.onerror = null
+
+            // Do not let a late image/HEAD result overwrite a newer entry.
+            if (blobUrlCache.get(id) === entry) blobUrlCache.set(id, result)
+            resolve(blobUrlCache.get(id) ?? result)
+        }
+
+        const handleLoad = () => {
+            const width = probe.naturalWidth || entry.width
+            const height = probe.naturalHeight || entry.height
+            settle({
+                status: 'ready',
+                type: 'image',
+                url: entry.url,
+                width: width || undefined,
+                height: height || undefined,
+            })
+        }
+
+        probe.onload = handleLoad
+        // Legacy assets may not have inlay_info. Probe their Content-Type only
+        // after image loading fails, and share that result with every waiter.
+        probe.onerror = async () => {
+            try {
+                const head = await fetch(entry.url, { method: 'HEAD' })
+                if (!head.ok) {
+                    settle(createFailedInlayEntry(entry, head.status !== 404 && head.status !== 410))
+                    return
+                }
+                const contentType = head.headers.get('content-type') || ''
+                if (contentType.startsWith('video/')) {
+                    settle({ status: 'ready', type: 'video', url: entry.url })
+                } else if (contentType.startsWith('audio/')) {
+                    settle({ status: 'ready', type: 'audio', url: entry.url })
+                } else {
+                    // The image GET may have failed transiently even when HEAD
+                    // succeeds (including a normal image Content-Type).
+                    settle(createFailedInlayEntry(entry, true))
+                }
+            } catch {
+                settle(createFailedInlayEntry(entry, true))
+            }
+        }
+
+        probe.src = entry.url
+        if (probe.complete && probe.naturalWidth > 0) queueMicrotask(handleLoad)
+    })
+
+    entry.loadPromise = loadPromise
+    return loadPromise
+}
+
+function createReadyInlayElement(entry: InlayCacheEntry): HTMLElement | null {
+    switch (entry.type) {
+        case 'image': {
+            const img = document.createElement('img')
+            img.style.animation = 'risu-fade-in 0.3s ease-out'
+            const dimensions = getInlayDimensions(entry)
+            if (dimensions) {
+                img.width = dimensions.width
+                img.height = dimensions.height
+            }
+            img.src = entry.url
+            return img
+        }
+        case 'video': {
+            const video = document.createElement('video')
+            video.controls = true
+            const source = document.createElement('source')
+            source.src = entry.url
+            source.type = 'video/mp4'
+            video.appendChild(source)
+            return video
+        }
+        case 'audio': {
+            const audio = document.createElement('audio')
+            audio.controls = true
+            const source = document.createElement('source')
+            source.src = entry.url
+            source.type = 'audio/mpeg'
+            audio.appendChild(source)
+            return audio
+        }
+        default:
+            return null
+    }
+}
+
 // Global resolve queue for inlay placeholders
 const resolveQueue: { el: HTMLElement, id: string, type: string }[] = []
+const resolvingInlayPlaceholders = new WeakSet<HTMLElement>()
 let isResolvingPlaceholders = false
+
+async function resolveQueuedInlay(el: HTMLElement, id: string) {
+    try {
+        let entry = blobUrlCache.get(id) ?? createLoadingInlayEntry(id)
+        if (!blobUrlCache.has(id)) blobUrlCache.set(id, entry)
+        if (entry.status === 'error' && entry.retryAt !== undefined && entry.retryAt <= Date.now()) {
+            const retryEntry = createLoadingInlayEntry(id, {
+                height: entry.height,
+                retryCount: entry.retryCount,
+                width: entry.width,
+            })
+            if (blobUrlCache.get(id) === entry) blobUrlCache.set(id, retryEntry)
+            entry = blobUrlCache.get(id) ?? retryEntry
+        }
+        // Preserve the existing hide-images fast path: do not download or
+        // decode an image that will be removed immediately.
+        if (DBState.db.hideAllImages && entry.type === 'image') {
+            el.remove()
+            return
+        }
+        if (entry.status === 'loading') entry = await ensureInlayLoaded(id, entry)
+
+        // The message may have been remounted while the shared load was in
+        // flight. Never let an old waiter replace a new placeholder.
+        if (!el.parentNode || el.dataset.inlayId !== id) return
+        if (DBState.db.hideAllImages && entry.type === 'image') {
+            el.remove()
+            return
+        }
+        if (entry.status !== 'ready') {
+            if (entry.retryAt !== undefined) {
+                const retryDelay = Math.max(0, entry.retryAt - Date.now())
+                setTimeout(() => {
+                    if (!el.parentNode || el.dataset.inlayId !== id) return
+                    void resolveQueuedInlay(el, id)
+                }, retryDelay)
+                return
+            }
+            el.replaceWith(createMissingInlayPlaceholder(id))
+            return
+        }
+
+        const replacement = createReadyInlayElement(entry)
+        if (replacement) el.replaceWith(replacement)
+    } catch (e) {
+        console.error(`[Inlay] Failed to load ${id}`, e)
+        if (el.parentNode) el.replaceWith(createMissingInlayPlaceholder(id))
+    }
+}
 
 async function processInlayQueue() {
     if (isResolvingPlaceholders || resolveQueue.length === 0) return
     isResolvingPlaceholders = true
 
-    while (resolveQueue.length > 0) {
-        const batch = resolveQueue.splice(0, 20)
+    try {
+        while (resolveQueue.length > 0) {
+            const batch = resolveQueue.splice(0, 20)
+            const unknownIds = Array.from(new Set(
+                batch
+                    .filter(({ id }) => !blobUrlCache.has(id))
+                    .map(({ id }) => id)
+            ))
 
-        const unknownIds = batch
-            .filter(({ id }) => !blobUrlCache.has(id))
-            .map(({ id }) => id)
-
-        if (unknownIds.length > 0) {
-            if (DBState.db.inlayImagePriority) {
-                // Fast path: assume image, let img.onerror handle video/audio
-                for (const id of unknownIds) {
-                    blobUrlCache.set(id, { url: assetUrl(`inlay/${id}`), type: 'image' })
-                }
-            } else {
-                // Accurate path: fetch type info first
-                try {
-                    const infos = await getInlayInfosBatch(unknownIds)
-                    for (const id of unknownIds) {
-                        const type = infos[id]?.type ?? 'image'
-                        blobUrlCache.set(id, { url: assetUrl(`inlay/${id}`), type })
-                    }
-                } catch {
-                    for (const id of unknownIds) {
-                        blobUrlCache.set(id, { url: assetUrl(`inlay/${id}`), type: 'image' })
-                    }
-                }
-            }
-        }
-
-        for (const { el, id } of batch) {
-            try {
-                if (!el.parentNode) continue
-
-                const cached = blobUrlCache.get(id)
-                const url = cached?.url ?? assetUrl(`inlay/${id}`)
-                const type = cached?.type ?? 'image'
-                if (!cached) blobUrlCache.set(id, { url, type })
-
-                switch (type) {
-                    case 'image':
-                        if (DBState.db.hideAllImages) { el.remove(); break }
-                        const img = document.createElement('img')
-                        img.src = url
-                        img.style.animation = 'risu-fade-in 0.3s ease-out'
-                        // Fallback for legacy inlays without inlay_info:
-                        // if <img> fails, probe Content-Type and swap to video/audio
-                        img.onerror = async () => {
-                            try {
-                                const head = await fetch(url, { method: 'HEAD' })
-                                const ct = head.headers.get('content-type') || ''
-                                if (ct.startsWith('video/')) {
-                                    blobUrlCache.set(id, { url, type: 'video' })
-                                    const video = document.createElement('video')
-                                    video.controls = true
-                                    const src = document.createElement('source')
-                                    src.src = url; src.type = ct
-                                    video.appendChild(src)
-                                    img.replaceWith(video)
-                                } else if (ct.startsWith('audio/')) {
-                                    blobUrlCache.set(id, { url, type: 'audio' })
-                                    const audio = document.createElement('audio')
-                                    audio.controls = true
-                                    const src = document.createElement('source')
-                                    src.src = url; src.type = ct
-                                    audio.appendChild(src)
-                                    img.replaceWith(audio)
-                                } else {
-                                    img.replaceWith(createMissingInlayPlaceholder(id))
-                                }
-                            } catch {
-                                img.replaceWith(createMissingInlayPlaceholder(id))
-                            }
+            if (unknownIds.length > 0) {
+                if (DBState.db.inlayImagePriority) {
+                    // Fast path: assume image, let the shared probe detect media.
+                    for (const id of unknownIds) blobUrlCache.set(id, createLoadingInlayEntry(id))
+                } else {
+                    // Accurate path: fetch type and dimensions first.
+                    try {
+                        const infos = await getInlayInfosBatch(unknownIds)
+                        for (const id of unknownIds) {
+                            const info = infos[id]
+                            const type = info?.type ?? 'image'
+                            blobUrlCache.set(id, {
+                                status: type === 'image' ? 'loading' : 'ready',
+                                url: assetUrl(`inlay/${id}`),
+                                type,
+                                height: info?.height,
+                                width: info?.width,
+                            })
                         }
-                        el.replaceWith(img)
-                        break
-                    case 'video': {
-                        const video = document.createElement('video')
-                        video.controls = true
-                        const source = document.createElement('source')
-                        source.src = url
-                        source.type = 'video/mp4'
-                        video.appendChild(source)
-                        el.replaceWith(video)
-                        break
+                    } catch {
+                        for (const id of unknownIds) blobUrlCache.set(id, createLoadingInlayEntry(id))
                     }
-                    case 'audio': {
-                        const audio = document.createElement('audio')
-                        audio.controls = true
-                        const source = document.createElement('source')
-                        source.src = url
-                        source.type = 'audio/mpeg'
-                        audio.appendChild(source)
-                        el.replaceWith(audio)
-                        break
-                    }
-                }
-            } catch (e) {
-                console.error(`[Inlay] Failed to load ${id}`, e)
-                if (el.parentNode) {
-                    el.replaceWith(createMissingInlayPlaceholder(id))
                 }
             }
-        }
-    }
 
-    isResolvingPlaceholders = false
+            // Start all loads concurrently; each duplicate id shares one probe.
+            for (const { el, id } of batch) void resolveQueuedInlay(el, id)
+        }
+    } finally {
+        isResolvingPlaceholders = false
+        if (resolveQueue.length > 0) void processInlayQueue()
+    }
 }
 
 export function resolveInlayPlaceholders(root: HTMLElement) {
     if (!root) return
-    const placeholders = Array.from(root.querySelectorAll('[data-inlay-id]')) as HTMLElement[]
+    const placeholders = (Array.from(root.querySelectorAll('[data-inlay-id]')) as HTMLElement[])
+        .filter((el) => !resolvingInlayPlaceholders.has(el))
     if (placeholders.length === 0) return
 
     const observer = new IntersectionObserver((entries) => {
@@ -864,7 +1008,10 @@ export function resolveInlayPlaceholders(root: HTMLElement) {
         })
     }, { rootMargin: '200px' }) // Start loading a bit before they scroll into view
 
-    placeholders.forEach(el => observer.observe(el))
+    placeholders.forEach(el => {
+        resolvingInlayPlaceholders.add(el)
+        observer.observe(el)
+    })
 }
 
 export interface simpleCharacterArgument{


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models, check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated, check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

## Summary

Prevent the chat viewport from jumping upward when LightBoard illustration inlays finish loading and replace their placeholders.

This stabilizes both sides of the interaction: inlay rendering now avoids repeated late layout changes, and the chat screen preserves a stable visible-message anchor when structural changes still occur.

## Related Issues

None.

## Changes

- Add a shared per-inlay `loading` / `ready` / `error` lifecycle so duplicate placeholders and rerenders reuse one image probe.
- Keep placeholders in layout until media is ready, retain intrinsic dimensions before insertion, and use bounded exponential retry for transient failures.
- Skip media probing entirely when images are hidden.
- Add a reusable chat scroll-anchor action that:
    - tracks the visible message by stable chat ID and viewport offset;
    - distinguishes current-message resize from structural remounts or changes outside the current message;
    - respects native browser anchoring, user wheel/touch intent, and programmatic navigation;
    - suspends and rebases safely around instant and smooth `scrollToMessage` flows.
- Add regression coverage for duplicate/remounted inlays, retry limits, hidden images, native anchoring, delayed image growth, user scroll, and programmatic navigation.

## Impact

- Fixes the LightBoard illustration loading scroll jump while retaining the user's reading position.
- Benefits other `{{inlay...}}` renderers that can produce duplicate or delayed media placeholders.
- Reduces duplicate image probes and unnecessary reflows for the same inlay ID.
- Does not change module tokens, model/provider behavior, the storage/server API, or the database schema.

## Testing

Validated with Node 24.19.0 and pnpm 10.34.1 from a clean frozen install:

- `pnpm check` — passed with 0 errors (4 pre-existing accessibility warnings)
- `pnpm build` — passed
- `pnpm test` — client: 1,057 passed / 3 skipped; server: 99 passed
- `pnpm test:compat` — 67 passed / 5 skipped
- Focused regression tests — 15 passed
- Manual LightBoard test using the production build against existing local data — no upward jump after illustration images populated

## Additional Notes

The functional scope is limited to inlay loading and chat scroll anchoring. Existing build-size, CSS highlight, dynamic-import, and accessibility warnings are unchanged.
