### PR TITLE
fix: preserve inlay dimensions across async rerenders

### DIFF
--- a/src/ts/parser/parser.inlayDimensions.test.ts
+++ b/src/ts/parser/parser.inlayDimensions.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { getInlayInfosBatchMock } = vi.hoisted(() => ({
+    getInlayInfosBatchMock: vi.fn(),
+}))
+
+vi.mock('../stores.svelte', () => ({
+    DBState: {
+        db: {
+            hideAllImages: false,
+            inlayImagePriority: true,
+        },
+    },
+    selectedCharID: { subscribe: () => () => {} },
+    selIdState: { selId: 0 },
+}))
+
+vi.mock('../process/files/inlays', () => ({
+    getInlayInfosBatch: getInlayInfosBatchMock,
+}))
+
+import { parseInlayAssets, resolveInlayPlaceholders, trimMarkdown } from './parser.svelte'
+import { DBState } from '../stores.svelte'
+
+describe('inlay dimension loading', () => {
+    let intersectionCallbacks: IntersectionObserverCallback[]
+
+    beforeEach(() => {
+        DBState.db.hideAllImages = false
+        getInlayInfosBatchMock.mockReset()
+        intersectionCallbacks = []
+
+        class IntersectionObserverMock {
+            constructor(callback: IntersectionObserverCallback) {
+                intersectionCallbacks.push(callback)
+            }
+            disconnect() {}
+            observe() {}
+            takeRecords() { return [] }
+            unobserve() {}
+        }
+
+        vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        document.body.replaceChildren()
+    })
+
+    test('applies pending dimensions to an inlay remounted before metadata resolves', async () => {
+        const id = `remount-${crypto.randomUUID()}`
+        const token = `{{inlay::${id}}}`
+        let resolveInfo!: (value: Record<string, {
+            height: number
+            type: 'image'
+            width: number
+        }>) => void
+
+        getInlayInfosBatchMock.mockReturnValueOnce(new Promise((resolve) => {
+            resolveInfo = resolve
+        }))
+
+        const firstRoot = document.createElement('div')
+        firstRoot.innerHTML = parseInlayAssets(token)
+        document.body.appendChild(firstRoot)
+        resolveInlayPlaceholders(firstRoot)
+
+        const firstPlaceholder = firstRoot.querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[0]([
+            { isIntersecting: true, target: firstPlaceholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+
+        await vi.waitFor(() => expect(firstRoot.querySelector('img')).not.toBeNull())
+        const detachedImage = firstRoot.querySelector('img')!
+        firstRoot.remove()
+
+        const remountedHTML = parseInlayAssets(token)
+        expect(remountedHTML).toContain('data-inlay-image-id')
+
+        const secondRoot = document.createElement('div')
+        const sanitizedHTML = trimMarkdown(remountedHTML)
+        expect(sanitizedHTML).toContain('data-inlay-image-id')
+        secondRoot.innerHTML = sanitizedHTML
+        document.body.appendChild(secondRoot)
+        resolveInlayPlaceholders(secondRoot)
+        resolveInfo({
+            [id]: { height: 360, type: 'image', width: 1080 },
+        })
+
+        await vi.waitFor(() => {
+            const image = secondRoot.querySelector('img')!
+            expect(image.getAttribute('width')).toBe('1080')
+            expect(image.getAttribute('height')).toBe('360')
+            expect(image.hasAttribute('data-inlay-image-id')).toBe(false)
+        })
+
+        expect(detachedImage.hasAttribute('width')).toBe(false)
+        expect(getInlayInfosBatchMock).toHaveBeenCalledTimes(1)
+        expect(parseInlayAssets(token)).toContain('width="1080" height="360"')
+    })
+
+    test('does not apply late dimensions after images are hidden', async () => {
+        const id = `hidden-${crypto.randomUUID()}`
+        let resolveInfo!: (value: Record<string, {
+            height: number
+            type: 'image'
+            width: number
+        }>) => void
+
+        getInlayInfosBatchMock.mockReturnValueOnce(new Promise((resolve) => {
+            resolveInfo = resolve
+        }))
+
+        const root = document.createElement('div')
+        root.innerHTML = parseInlayAssets(`{{inlay::${id}}}`)
+        document.body.appendChild(root)
+        resolveInlayPlaceholders(root)
+
+        const placeholder = root.querySelector<HTMLElement>('[data-inlay-id]')!
+        intersectionCallbacks[0]([
+            { isIntersecting: true, target: placeholder } as unknown as IntersectionObserverEntry,
+        ], {} as IntersectionObserver)
+
+        await vi.waitFor(() => expect(root.querySelector('img')).not.toBeNull())
+        const image = root.querySelector('img')!
+        DBState.db.hideAllImages = true
+        resolveInfo({
+            [id]: { height: 360, type: 'image', width: 1080 },
+        })
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(image.hasAttribute('width')).toBe(false)
+        expect(image.hasAttribute('height')).toBe(false)
+    })
+})

--- a/src/ts/parser/parser.svelte.ts
+++ b/src/ts/parser/parser.svelte.ts
@@ -702,6 +702,7 @@ type InlayCacheEntry = { url: string; type: string; width?: number; height?: num
 type InlayDimensions = { width: number; height: number }
 
 const blobUrlCache = new Map<string, InlayCacheEntry>()
+const inlayDimensionRequests = new Map<string, Promise<InlayDimensions | undefined>>()
 const inlayImageExts = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']
 
 /** Build a direct-serve URL for a KV key via /api/asset/ */
@@ -727,6 +728,55 @@ function applyInlayDimensions(img: HTMLImageElement, source: { width?: number; h
     if(!dimensions) return
     img.setAttribute('width', String(dimensions.width))
     img.setAttribute('height', String(dimensions.height))
+}
+
+function requestInlayDimensions(ids: string[]) {
+    const idsToRequest = ids.filter((id) => !inlayDimensionRequests.has(id))
+    if(idsToRequest.length === 0) return
+
+    const infosRequest = getInlayInfosBatch(idsToRequest)
+    for(const id of idsToRequest){
+        const request = infosRequest.then((infos) => {
+            const cached = blobUrlCache.get(id)
+            if(!cached || cached.type !== 'image') return undefined
+
+            const dimensions = getInlayDimensions(infos[id])
+            if(!dimensions) return undefined
+            cached.width = dimensions.width
+            cached.height = dimensions.height
+            return dimensions
+        }).catch(() => undefined)
+
+        inlayDimensionRequests.set(id, request)
+        void request.finally(() => {
+            if(inlayDimensionRequests.get(id) === request){
+                inlayDimensionRequests.delete(id)
+            }
+        })
+    }
+}
+
+function applyPendingInlayDimensions(img: HTMLImageElement, id: string, cached: InlayCacheEntry | undefined) {
+    img.removeAttribute('data-inlay-image-id')
+    if(DBState.db.hideAllImages || cached?.type !== 'image' || img.getAttribute('src') !== cached.url) return
+
+    applyInlayDimensions(img, cached)
+    if(getInlayDimensions(cached)) return
+
+    const request = inlayDimensionRequests.get(id)
+    if(!request) return
+    void request.then((dimensions) => {
+        const current = blobUrlCache.get(id)
+        if(
+            dimensions
+            && img.isConnected
+            && !DBState.db.hideAllImages
+            && current?.type === 'image'
+            && img.getAttribute('src') === current.url
+        ){
+            applyInlayDimensions(img, dimensions)
+        }
+    })
 }
 
 function createMissingInlayPlaceholder(id: string): HTMLDivElement {
@@ -756,7 +806,7 @@ export function parseInlayAssets(data:string){
             let prefix = inlayType !== 'inlay' ? `<div class="risu-inlay-image">` : ''
             let postfix = inlayType !== 'inlay' ? `</div>\n\n` : ''
 
-            let cached = blobUrlCache.get(id)
+            const cached = blobUrlCache.get(id)
             if(!cached){
                 // If not in memory cache, inject placeholder
                 const placeholder = `${prefix}<div data-inlay-id="${id}" data-inlay-type="${inlayType}" class="risu-inlay-placeholder risu-loading-spinner" style="width: 100%; min-height: 100px; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.1); border-radius: 8px;"></div>${postfix}`
@@ -772,7 +822,10 @@ export function parseInlayAssets(data:string){
                         data = data.replace(inlay, '')
                         break
                     }
-                    data = data.replace(inlay, `${prefix}<img src="${url}"${getInlayDimensionAttributes(cached)}/>${postfix}`)
+                    const pendingDimensionAttribute = !getInlayDimensions(cached) && inlayDimensionRequests.has(id)
+                        ? ` data-inlay-image-id="${id}"`
+                        : ''
+                    data = data.replace(inlay, `${prefix}<img src="${url}"${getInlayDimensionAttributes(cached)}${pendingDimensionAttribute}/>${postfix}`)
                     break
                 case 'video':
                     data = data.replace(inlay, `${prefix}<video controls><source src="${url}" type="video/mp4"></video>${postfix}`)
@@ -796,13 +849,10 @@ async function processInlayQueue() {
 
     while (resolveQueue.length > 0) {
         const batch = resolveQueue.splice(0, 20)
-        // <img> elements inserted below, so late-arriving dimensions can still
-        // reserve their box before the image finishes decoding.
-        const insertedImages = new Map<string, HTMLImageElement[]>()
 
-        const unknownIds = batch
+        const unknownIds = Array.from(new Set(batch
             .filter(({ id }) => !blobUrlCache.has(id))
-            .map(({ id }) => id)
+            .map(({ id }) => id)))
 
         if (unknownIds.length > 0) {
             if (DBState.db.inlayImagePriority) {
@@ -810,22 +860,9 @@ async function processInlayQueue() {
                 for (const id of unknownIds) {
                     blobUrlCache.set(id, { url: assetUrl(`inlay/${id}`), type: 'image' })
                 }
-                // Dimensions are fetched without blocking the image load; when
-                // they arrive, size the already-inserted <img> so it doesn't
-                // jump from 0 height once decoded.
-                getInlayInfosBatch(unknownIds).then((infos) => {
-                    for (const id of unknownIds) {
-                        const cached = blobUrlCache.get(id)
-                        if(!cached) continue
-                        const dimensions = getInlayDimensions(infos[id])
-                        if(!dimensions) continue
-                        cached.width = dimensions.width
-                        cached.height = dimensions.height
-                        for (const img of insertedImages.get(id) ?? []) {
-                            if (img.isConnected) applyInlayDimensions(img, dimensions)
-                        }
-                    }
-                }).catch(() => {})
+                // Keep one metadata request available to every render of this
+                // id until its intrinsic dimensions have reached the cache.
+                requestInlayDimensions(unknownIds)
             } else {
                 // Accurate path: fetch type info first
                 try {
@@ -858,8 +895,7 @@ async function processInlayQueue() {
                         if (DBState.db.hideAllImages) { el.remove(); break }
                         const img = document.createElement('img')
                         img.src = url
-                        applyInlayDimensions(img, cached)
-                        insertedImages.set(id, [...(insertedImages.get(id) ?? []), img])
+                        applyPendingInlayDimensions(img, id, cached)
                         img.style.animation = 'risu-fade-in 0.3s ease-out'
                         // Fallback for legacy inlays without inlay_info:
                         // if <img> fails, probe Content-Type and swap to video/audio
@@ -927,6 +963,13 @@ async function processInlayQueue() {
 
 export function resolveInlayPlaceholders(root: HTMLElement) {
     if (!root) return
+
+    const pendingDimensionImages = Array.from(root.querySelectorAll<HTMLImageElement>('img[data-inlay-image-id]'))
+    for(const img of pendingDimensionImages){
+        const id = img.getAttribute('data-inlay-image-id')
+        if(id) applyPendingInlayDimensions(img, id, blobUrlCache.get(id))
+    }
+
     const placeholders = Array.from(root.querySelectorAll('[data-inlay-id]')) as HTMLElement[]
     if (placeholders.length === 0) return
 
@@ -1037,7 +1080,7 @@ export async function ParseMarkdown(
 
 const trimPurifyConfig = {
     ADD_TAGS: ["iframe", "style", "risu-style", "x-em", 'annotation', 'semantics', 'mrow', 'mi', 'mo', 'mn', 'msup', 'msub', 'mfrac', 'msqrt'],
-    ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "risu-ctrl" ,"risu-btn", 'risu-trigger', 'risu-mark', 'risu-id', 'x-hl-lang', 'x-hl-text', 'data-inlay-id', 'data-inlay-type'],
+    ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "risu-ctrl" ,"risu-btn", 'risu-trigger', 'risu-mark', 'risu-id', 'x-hl-lang', 'x-hl-text', 'data-inlay-id', 'data-inlay-type', 'data-inlay-image-id'],
 }
 
 // LRU cache for DOMPurify + decodeStyle results.


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] Model/provider checks are not applicable; this does not change model or provider behavior.
- [x] AI-generated change checks
    - [x] The code path and race condition were reviewed.
    - [x] Unnecessary or unrelated changes were removed.
    - [x] The change is limited to the parser and focused regression coverage.

## Summary

Fix a PocketRisu parser cache-consistency bug in the fast inlay path.

That path publishes a provisional image cache entry before its stored dimensions finish loading. If the same content is rendered or remounted during that window, the new image can read the provisional entry without reconnecting to the pending metadata request, so its intrinsic dimensions never reach that render.

## Related Issues

None.

## Changes

- Share one pending dimension lookup per inlay ID until the cache is complete.
- Reconnect both DOM-created and sanitized/remounted images to that lookup.
- Persist resolved dimensions in the existing cache and apply them only to the current matching image.
- Deduplicate batch IDs and ignore late results after images are hidden or their source/type changes.
- Add regression coverage for the remount race and the late-hide race.

## Impact

- Preserves cached intrinsic width and height across asynchronous rerenders.
- Keeps immediate image loading and the existing video/audio fallback behavior.
- Remains parser-local: no global scroll correction, storage API, database schema, or model/provider changes.

## Testing

Validated from a clean frozen install with Node 24.19.0 and pnpm 10.34.1:

- `pnpm check` — passed, 0 errors (4 pre-existing accessibility warnings)
- `pnpm build` — passed
- `pnpm test` — passed, 1,303 tests / 3 skipped / 0 failed
- `pnpm test:compat` — passed, 85 tests / 5 skipped / 0 failed
- Focused inlay-dimension regression tests — 2 passed

## Additional Notes

This is a parser-local follow-up to `53699f47`. It closes the remaining pending-metadata remount race without introducing chat viewport management or changing inlay token behavior.
