### PR TITLE
feat: support stable per-module model routing for LightBoard

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1455,6 +1455,7 @@ export const languageEnglish = {
     modelPresetTabTest: "Test",
     modelPresetTabModules: "Module Binding",
     moduleModelBindingEnable: "Per-Module Model Binding",
+    lightBoardModuleBindingCompatibilityMode: "LightBoard Compatibility Mode",
     moduleModelBindingUnset: "Not set",
     moduleModelBindingEmpty: "No installed module makes model calls.",
     moduleModelBindingDangling: "The assigned preset no longer exists. Pick another, or re-import the preset to reconnect.",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1580,6 +1580,7 @@ export const languageKorean = {
   modelPresetTabTest: "테스트",
   modelPresetTabModules: "모듈 분리 바인딩",
   moduleModelBindingEnable: "모듈별 모델 지정 사용",
+  lightBoardModuleBindingCompatibilityMode: "라이트보드 호환성 모드",
   moduleModelBindingUnset: "지정 안 함",
   moduleModelBindingEmpty: "모델을 호출하는 모듈이 없습니다.",
   moduleModelBindingDangling: "지정된 프리셋을 찾을 수 없습니다. 다시 선택하거나, 프리셋을 다시 불러오면 연결됩니다.",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -1793,6 +1793,7 @@ export const languageChineseTraditional = {
     "modelPresetTabTest": "測試",
     "modelPresetTabModules": "模組綁定",
     "moduleModelBindingEnable": "各模組模型綁定",
+    "lightBoardModuleBindingCompatibilityMode": "LightBoard 相容模式",
     "moduleModelBindingUnset": "未指定",
     "moduleModelBindingEmpty": "沒有會呼叫模型的已安裝模組。",
     "moduleModelBindingDangling": "指定的預設已不存在。請另選一個，或重新匯入該預設以重新連結。",

--- a/src/lib/Setting/Pages/Model/ModuleModelBindingList.svelte
+++ b/src/lib/Setting/Pages/Model/ModuleModelBindingList.svelte
@@ -9,20 +9,27 @@
     import OptionInput from 'src/lib/UI/GUI/OptionInput.svelte'
     import SettingRowLayout from 'src/lib/Setting/Wrappers/SettingRowLayout.svelte'
     import type { SettingItem } from 'src/ts/setting/types'
-    import { listModelCallingModules } from 'src/ts/process/moduleModelBinding'
+    import {
+        getModuleBindingPresetId,
+        listModelCallingModules,
+        moduleBindingKeys,
+    } from 'src/ts/process/moduleModelBinding'
 
     // Read from db.modules (every installed module), not getModules() — the
     // latter is scoped to the character/chat currently open, which would make
     // this global page show a different list depending on where the user came from.
-    let modules = $derived(listModelCallingModules(DBState.db.modules ?? []))
+    let modules = $derived(listModelCallingModules(
+        DBState.db.modules ?? [],
+        DBState.db.lightBoardModuleBindingCompatibilityMode ?? true,
+    ))
 
     let bindings = $derived(DBState.db.moduleModelBindings ?? {})
     let presets = $derived(DBState.db.modelPresets ?? [])
 
     /** A stored id whose preset no longer exists. Kept, not cleared, so a
      * re-imported preset reconnects; surfaced here so it does not look bound. */
-    function isDangling(moduleId: string): boolean {
-        const id = bindings[moduleId]
+    function isDangling(module: typeof modules[number]): boolean {
+        const id = getModuleBindingPresetId(module, bindings)
         return !!id && !presets.some((p) => p.id === id)
     }
 
@@ -34,12 +41,16 @@
         }
     }
 
-    function setBinding(moduleId: string, presetId: string) {
+    function setBinding(module: typeof modules[number], presetId: string) {
         DBState.db.moduleModelBindings ??= {}
+        const [preferredKey, ...legacyKeys] = moduleBindingKeys(module)
         if (presetId) {
-            DBState.db.moduleModelBindings[moduleId] = presetId
+            DBState.db.moduleModelBindings[preferredKey] = presetId
         } else {
-            delete DBState.db.moduleModelBindings[moduleId]
+            delete DBState.db.moduleModelBindings[preferredKey]
+        }
+        for (const legacyKey of legacyKeys) {
+            delete DBState.db.moduleModelBindings[legacyKey]
         }
     }
 </script>
@@ -61,8 +72,8 @@
                     <ShSelect
                         className="w-48"
                         size="sm"
-                        value={isDangling(module.id) ? '' : (bindings[module.id] ?? '')}
-                        onchange={(e) => setBinding(module.id, e.currentTarget.value)}
+                        value={isDangling(module) ? '' : (getModuleBindingPresetId(module, bindings) ?? '')}
+                        onchange={(e) => setBinding(module, e.currentTarget.value)}
                     >
                         <OptionInput value="">{language.moduleModelBindingUnset}</OptionInput>
                         {#each presets as preset (preset.id)}
@@ -71,7 +82,7 @@
                     </ShSelect>
                 {/snippet}
             </SettingRowLayout>
-            {#if isDangling(module.id)}
+            {#if isDangling(module)}
                 <p class="text-xs text-draculared pb-3">{language.moduleModelBindingDangling}</p>
             {/if}
         {/each}

--- a/src/lib/Setting/Wrappers/SettingCheck.svelte
+++ b/src/lib/Setting/Wrappers/SettingCheck.svelte
@@ -15,6 +15,9 @@
     let { item, ctx }: Props = $props();
 
     let localValue: any = $state(untrack(() => getSettingValue(item, ctx)));
+    let disabled = $derived(
+        typeof item.disabled === 'function' ? item.disabled(ctx) : (item.disabled ?? false),
+    );
 
     // Sync: DB → local (one-way read)
     $effect(() => {
@@ -36,7 +39,7 @@
 {#if ctx.layout === 'row'}
     <SettingRowLayout {item}>
         {#snippet control()}
-            <ShSwitch checked={!!localValue} onCheckedChange={(v) => (localValue = v)} />
+            <ShSwitch checked={!!localValue} {disabled} onCheckedChange={(v) => (localValue = v)} />
         {/snippet}
     </SettingRowLayout>
 {:else}

--- a/src/ts/process/moduleModelBinding.test.ts
+++ b/src/ts/process/moduleModelBinding.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest'
-import { listModelCallingModules } from './moduleModelBinding'
+import {
+    getModuleBindingPresetId,
+    isLightBoardModule,
+    listModelCallingModules,
+    migrateModuleBindingKeys,
+    resolveModuleRoutingSignature,
+} from './moduleModelBinding'
 
 function mod(id: string, opts: { lowLevelAccess?: boolean; effects?: string[] } = {}) {
     return {
@@ -40,10 +46,95 @@ describe('listModelCallingModules', () => {
         expect(listModelCallingModules([mod('a', { lowLevelAccess: true })])).toEqual([])
     })
 
+    test('includes LightBoard extensions without direct LLM access as binding slots', () => {
+        const extension = mod('illustration')
+        extension.namespace = 'lb-xnai'
+        expect(listModelCallingModules([extension])).toEqual([extension])
+    })
+
+    test('keeps namespace-less legacy LightBoard packages visible as binding slots', () => {
+        const legacy = mod('legacy')
+        legacy.name = '🔦라이트보드 NPC LIST'
+        expect(isLightBoardModule(legacy)).toBe(true)
+        expect(listModelCallingModules([legacy])).toEqual([legacy])
+    })
+
+    test('hides every LightBoard slot when compatibility mode is disabled', () => {
+        const base = mod('base', { lowLevelAccess: true, effects: ['runLLM'] })
+        base.namespace = 'lightboard'
+        const extension = mod('illustration')
+        extension.namespace = 'lb-xnai'
+        const normal = mod('normal', { lowLevelAccess: true, effects: ['runLLM'] })
+
+        expect(listModelCallingModules([base, extension, normal], false)).toEqual([normal])
+    })
+
     test('keeps installed order and drops the rest', () => {
         const a = mod('a', { lowLevelAccess: true, effects: ['runLLM'] })
         const b = mod('b', { lowLevelAccess: true, effects: ['v2SetVar'] })
         const c = mod('c', { lowLevelAccess: true, effects: ['triggercode'] })
         expect(listModelCallingModules([a, b, c])).toEqual([a, c])
+    })
+})
+
+describe('module binding identity', () => {
+    test('prefers a namespace binding over the legacy UUID binding', () => {
+        const module = mod('uuid-1', { lowLevelAccess: true })
+        module.namespace = 'lb-xnai'
+        expect(getModuleBindingPresetId(module, {
+            'uuid-1': 'legacy-preset',
+            'namespace:lb-xnai': 'stable-preset',
+        })).toBe('stable-preset')
+    })
+
+    test('migrates live UUID bindings without deleting orphaned entries', () => {
+        const module = mod('uuid-1', { lowLevelAccess: true })
+        module.namespace = 'lb-xnai'
+        const bindings = { 'uuid-1': 'preset-1', 'old-uuid': 'preset-orphan' }
+
+        expect(migrateModuleBindingKeys([module], bindings)).toBe(true)
+        expect(bindings).toEqual({
+            'namespace:lb-xnai': 'preset-1',
+            'old-uuid': 'preset-orphan',
+        })
+    })
+
+    test('matches one exact LightBoard routing signature to a module namespace', () => {
+        const owner = mod('owner', { lowLevelAccess: true })
+        owner.namespace = 'lightboard'
+        const illustration = mod('illustration', { lowLevelAccess: true })
+        illustration.namespace = 'lb-xnai'
+
+        expect(resolveModuleRoutingSignature(
+            owner.id,
+            [{ content: 'generated request\n[lb-routing/lb-xnai]' }],
+            [owner, illustration],
+        )).toBe('illustration')
+    })
+
+    test('rejects multiple routing signatures', () => {
+        const owner = mod('owner', { lowLevelAccess: true })
+        owner.namespace = 'lightboard'
+        const illustration = mod('illustration', { lowLevelAccess: true })
+        illustration.namespace = 'lb-xnai'
+
+        expect(resolveModuleRoutingSignature(
+            owner.id,
+            [{ content: '[lb-routing/lb-xnai]\n[lb-routing/lb-news]' }],
+            [owner, illustration],
+        )).toBeUndefined()
+    })
+
+    test('rejects a LightBoard marker from another module owner', () => {
+        const owner = mod('owner', { lowLevelAccess: true })
+        owner.namespace = 'another-module'
+        const illustration = mod('illustration', { lowLevelAccess: true })
+        illustration.namespace = 'lb-xnai'
+
+        expect(resolveModuleRoutingSignature(
+            owner.id,
+            [{ content: '[lb-routing/lb-xnai]' }],
+            [owner, illustration],
+        )).toBeUndefined()
     })
 })

--- a/src/ts/process/moduleModelBinding.ts
+++ b/src/ts/process/moduleModelBinding.ts
@@ -1,5 +1,75 @@
 import type { RisuModule } from './modules'
 
+export const MODULE_NAMESPACE_BINDING_PREFIX = 'namespace:'
+
+/**
+ * Module UUIDs are regenerated on import. A namespace is authored by the
+ * module and survives a re-import, so prefer it whenever one exists.
+ */
+export function moduleBindingKeys(module: Pick<RisuModule, 'id' | 'namespace'>): string[] {
+    return module.namespace
+        ? [`${MODULE_NAMESPACE_BINDING_PREFIX}${module.namespace}`, module.id]
+        : [module.id]
+}
+
+export function getModuleBindingPresetId(
+    module: Pick<RisuModule, 'id' | 'namespace'> | undefined,
+    bindings: Record<string, string> | undefined,
+): string | undefined {
+    if (!module || !bindings) return undefined
+    return moduleBindingKeys(module)
+        .map((key) => bindings[key])
+        .find((presetId) => !!presetId)
+}
+
+/** Moves live UUID bindings to the stable namespace key without touching
+ * orphaned entries. Those may reconnect if their original module is restored. */
+export function migrateModuleBindingKeys(
+    modules: Pick<RisuModule, 'id' | 'namespace'>[],
+    bindings: Record<string, string>,
+): boolean {
+    let changed = false
+    for (const module of modules) {
+        if (!module.namespace || !bindings[module.id]) continue
+        const stableKey = `${MODULE_NAMESPACE_BINDING_PREFIX}${module.namespace}`
+        bindings[stableKey] ??= bindings[module.id]
+        delete bindings[module.id]
+        changed = true
+    }
+    return changed
+}
+
+const ROUTING_SIGNATURE = /(?:^|\n)\[lb-routing\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\](?=$|\n)/g
+
+/**
+ * LightBoard puts a stable routing marker in its own auxiliary prompts. Match
+ * it only for an already-attributed module request, so normal chat text cannot
+ * select a module preset. Multiple or unknown markers deliberately fall back
+ * to the module that made the request.
+ */
+export function resolveModuleRoutingSignature(
+    ownerModuleId: string | undefined,
+    messages: readonly { content?: string }[] | undefined,
+    modules: Pick<RisuModule, 'id' | 'namespace'>[],
+): string | undefined {
+    if (!ownerModuleId || !messages) return undefined
+    const owner = modules.find((module) => module.id === ownerModuleId)
+    if (owner?.namespace !== 'lightboard') return undefined
+
+    const signatures = new Set<string>()
+    for (const message of messages) {
+        if (typeof message.content !== 'string') continue
+        for (const match of message.content.matchAll(ROUTING_SIGNATURE)) {
+            signatures.add(match[1])
+        }
+    }
+    if (signatures.size !== 1) return undefined
+
+    const [signature] = signatures
+    const matches = modules.filter((module) => module.namespace === signature)
+    return matches.length === 1 ? matches[0].id : undefined
+}
+
 /**
  * Trigger effects that issue a direct LLM request attributable to the module.
  *
@@ -19,6 +89,21 @@ const LLM_EFFECT_TYPES = new Set(['runLLM', 'v2RunLLM'])
 const CODE_EFFECT_TYPES = new Set(['triggerlua', 'triggercode'])
 
 /**
+ * LightBoard extensions delegate their LLM work to the `lightboard` backend.
+ * They need a selectable slot even when they have no low-level permission or
+ * direct model-call trigger of their own. Namespace is the canonical identity;
+ * the name check preserves compatibility with older LightBoard packages that
+ * predate namespaces.
+ */
+export function isLightBoardModule(module: Pick<RisuModule, 'name' | 'namespace'> | undefined): boolean {
+    if (!module) return false
+    return module.namespace === 'lightboard'
+        || module.namespace?.startsWith('lb-') === true
+        || module.name.includes('라이트보드')
+        || /\blightboard\b/i.test(module.name)
+}
+
+/**
  * Modules that can issue an LLM request, i.e. the candidates for a per-module
  * ModelPreset binding.
  *
@@ -28,13 +113,19 @@ const CODE_EFFECT_TYPES = new Set(['triggerlua', 'triggercode'])
  * provably cannot call a model, and importing such a module already required an
  * explicit user confirmation, which keeps this list short.
  */
-export function listModelCallingModules(modules: RisuModule[]): RisuModule[] {
-    return modules.filter((module) =>
-        module?.lowLevelAccess &&
-        module.trigger?.some((trigger) =>
-            trigger?.effect?.some((effect) =>
-                LLM_EFFECT_TYPES.has(effect?.type) || CODE_EFFECT_TYPES.has(effect?.type)
+export function listModelCallingModules(
+    modules: RisuModule[],
+    includeLightBoard = true,
+): RisuModule[] {
+    return modules.filter((module) => {
+        if (isLightBoardModule(module)) return includeLightBoard
+        return (
+            module?.lowLevelAccess
+            && module.trigger?.some((trigger) =>
+                trigger?.effect?.some((effect) =>
+                    LLM_EFFECT_TYPES.has(effect?.type) || CODE_EFFECT_TYPES.has(effect?.type)
+                )
             )
         )
-    )
+    })
 }

--- a/src/ts/process/request/modelPresetBinding.test.ts
+++ b/src/ts/process/request/modelPresetBinding.test.ts
@@ -123,6 +123,48 @@ describe('resolveChatModelBinding — per-module override', () => {
         expect(resolveChatModelBinding(presetChat, 'model', 'mod-1'))
             .toEqual({ kind: 'modelPreset', preset: MODULE_PRESET })
     })
+
+    test('a LightBoard routing signature selects the delegated module binding', () => {
+        mockDb.modules = [
+            { id: 'lightboard-owner', namespace: 'lightboard' },
+            { id: 'illustration', namespace: 'lb-xnai' },
+        ]
+        mockDb.moduleModelBindings = {
+            'lightboard-owner': 'p-main',
+            'namespace:lb-xnai': 'p-module',
+        }
+
+        expect(resolveChatModelBinding(
+            classicChat,
+            'otherAx',
+            'lightboard-owner',
+            [{ content: 'internal prompt\n[lb-routing/lb-xnai]' }],
+        )).toEqual({ kind: 'modelPreset', preset: MODULE_PRESET })
+    })
+
+    test('an unknown or ambiguous routing signature keeps the owner binding', () => {
+        mockDb.modules = [{ id: 'lightboard-owner', namespace: 'lightboard' }]
+        mockDb.moduleModelBindings = { 'lightboard-owner': 'p-module' }
+
+        expect(resolveChatModelBinding(
+            classicChat,
+            'otherAx',
+            'lightboard-owner',
+            [{ content: '[lb-routing/lb-xnai]\n[lb-routing/lb-news]' }],
+        )).toEqual({ kind: 'modelPreset', preset: MODULE_PRESET })
+    })
+
+    test('a routing signature is ignored without a module-owned request', () => {
+        mockDb.modules = [{ id: 'illustration', namespace: 'lb-xnai' }]
+        mockDb.moduleModelBindings = { 'namespace:lb-xnai': 'p-module' }
+
+        expect(resolveChatModelBinding(
+            classicChat,
+            'otherAx',
+            undefined,
+            [{ content: '[lb-routing/lb-xnai]' }],
+        )).toEqual({ kind: 'classic' })
+    })
 })
 
 function presetWith(opts: { schema?: any[]; userValues?: any; defaults?: any } = {}) {

--- a/src/ts/process/request/modelPresetBinding.ts
+++ b/src/ts/process/request/modelPresetBinding.ts
@@ -2,6 +2,10 @@ import { getDatabase, type Chat, type Database } from 'src/ts/storage/database.s
 import type { AdapterCredential } from 'src/ts/preset/adapter'
 import { VISION_CAPABLE_ADAPTER_KINDS, type ModelPreset } from 'src/ts/preset/types'
 import type { ModelModeExtended } from './shared'
+import {
+    getModuleBindingPresetId,
+    resolveModuleRoutingSignature,
+} from '../moduleModelBinding'
 
 /**
  * P4 dual-regime resolution (plan v6 §7, model-preset-p4-task).
@@ -43,6 +47,7 @@ export function resolveChatModelBinding(
     chat: Chat | null | undefined,
     mode: ModelModeExtended,
     moduleId?: string,
+    messages?: readonly { content?: string }[],
 ): ResolvedBinding {
     const db = getDatabase()
     const lock = db.nodeOnlyModelModeLock ?? 'none'
@@ -57,8 +62,21 @@ export function resolveChatModelBinding(
     // chat only ever takes this path when the user opted in. Dangling ids fall
     // through to normal resolution rather than blocking.
     if (moduleId && db.moduleModelBindingsEnabled) {
-        const bound = findPreset(db.moduleModelBindings?.[moduleId], db.modelPresets ?? [])
-        if (bound) return { kind: 'modelPreset', preset: bound }
+        const modules = db.modules ?? []
+        // A delegated module request can carry LightBoard's stable marker. It
+        // wins only when it resolves to one installed namespace; otherwise the
+        // actual script owner keeps the existing behaviour.
+        const routedModuleId = resolveModuleRoutingSignature(moduleId, messages, modules)
+        const candidateModuleIds = [routedModuleId, moduleId].filter((id): id is string => !!id)
+        for (const candidateModuleId of candidateModuleIds) {
+            const module = modules.find((entry) => entry.id === candidateModuleId)
+            const bound = findPreset(
+                getModuleBindingPresetId(module, db.moduleModelBindings)
+                    ?? db.moduleModelBindings?.[candidateModuleId],
+                db.modelPresets ?? [],
+            )
+            if (bound) return { kind: 'modelPreset', preset: bound }
+        }
     }
 
     // Effective regime. A global lock forces every chat into one regime; 'none'

--- a/src/ts/process/request/request.ts
+++ b/src/ts/process/request/request.ts
@@ -402,7 +402,7 @@ export async function requestChatDataMain(arg:requestDataArgument, model:ModelMo
     // is forced — fallbacks are classic model ids.
     if(!arg.staticModel){
         const currentChat = getCurrentChat()
-        const binding = resolveChatModelBinding(currentChat, model, arg.moduleId)
+        const binding = resolveChatModelBinding(currentChat, model, arg.moduleId, arg.formated)
         if(binding.kind === 'modelPreset'){
             return requestModelPreset(targ, applyPromptPresetParams(binding.preset, currentChat, model), abortSignal, model)
         }

--- a/src/ts/setting/moduleModelBindingData.ts
+++ b/src/ts/setting/moduleModelBindingData.ts
@@ -17,6 +17,14 @@ export const moduleModelBindingItems: SettingItem[] = [
         keywords: ['module', 'per-module', 'module binding', 'lua', 'trigger', 'script', '모듈', '모듈별', '모듈 분리 바인딩', '바인딩', '루아', '트리거', '스크립트'],
     },
     {
+        id: 'modelPreset.lightBoardModuleBindingCompatibilityMode',
+        type: 'check',
+        labelKey: 'lightBoardModuleBindingCompatibilityMode',
+        bindKey: 'lightBoardModuleBindingCompatibilityMode',
+        disabled: (ctx) => !ctx.db.moduleModelBindingsEnabled,
+        keywords: ['lightboard', 'light board', 'compatibility', '라이트보드', '호환성'],
+    },
+    {
         // The per-module rows are dynamic (one per installed module that can
         // call a model), so they cannot be declared as static items.
         id: 'modelPreset.moduleModelBindingList',

--- a/src/ts/setting/types.ts
+++ b/src/ts/setting/types.ts
@@ -64,6 +64,7 @@ export interface SelectOption {
     descriptionKey?: string;
     /** Optional condition — when provided, the option is only shown if this returns true */
     condition?: (ctx: SettingContext) => boolean;
+
 }
 
 /**
@@ -161,6 +162,12 @@ export interface SettingItem {
      * @param ctx - Contains db, modelInfo, and subModelInfo
      */
     condition?: (ctx: SettingContext) => boolean;
+
+    /**
+     * Condition function for disabling an otherwise visible input.
+     * Return true to disable it.
+     */
+    disabled?: boolean | ((ctx: SettingContext) => boolean);
     
     /** Type-specific options */
     options?: SettingOptions;

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -17,6 +17,7 @@ import { normalizeTranslatorPresetState, type TranslatorPreset } from '../transl
 import { safeStructuredClone } from '../polyfill';
 import { v4 as uuidv4 } from 'uuid';
 import { applyModelPresetDefaults } from '../preset/dbDefaults';
+import { migrateModuleBindingKeys } from '../process/moduleModelBinding';
 import type { ApiKeyPoolEntry, ModelBindingFields, ModelBindingSet, ModelPreset, ModelPresetMigrationSummary, RegistryCache } from '../preset/types';
 import { emptyModelBinding } from '../preset/types';
 import { isChatStub } from './chatStub';
@@ -730,7 +731,9 @@ export function setDatabase(data:Database){
     data.showPersonaInSidebar ??= true
     data.nodeOnlyModelModeLock ??= 'none'
     data.moduleModelBindingsEnabled ??= false
+    data.lightBoardModuleBindingCompatibilityMode ??= true
     data.moduleModelBindings ??= {}
+    migrateModuleBindingKeys(data.modules, data.moduleModelBindings)
     data.disableMobileDragDrop ??= false
     data.disableToggleBinding ??= false
     data.hideAllImages ??= false
@@ -1469,6 +1472,9 @@ export interface Database{
     // moduleModelBindingsEnabled is the master switch. Off (default) skips the
     // override branch entirely, so behaviour is byte-identical to before.
     moduleModelBindingsEnabled?: boolean
+    // Shows LightBoard's delegated extension modules as selectable binding
+    // slots. Kept on by default to preserve the expanded slot list.
+    lightBoardModuleBindingCompatibilityMode?: boolean
     moduleModelBindings?: Record<string, string>
     modelPresetMigrationVersion?: number
     modelPresetMigrationAppliedAt?: number


### PR DESCRIPTION
## PR Checklist

- [x] Have you added type definitions?
- [x] Have you tested your changes?
- [x] Have you checked that existing model binding behavior remains compatible?
- [x] Have you understood and reviewed the generated code?
- [x] Have you removed unnecessary or redundant changes?
- [x] Is the change reasonably scoped?
- [x] If your PR uses models, have you checked that the routing change is provider-agnostic? No provider-specific adapter code is changed.

## Summary

Add stable per-module ModelPreset routing for LightBoard and its extension modules.

LightBoard delegates extension requests through its base module, so those requests were previously attributed only to the base module. Module UUIDs are also regenerated when modules are imported, which can orphan saved bindings.

## Changes

- Prefer stable `namespace:<module namespace>` binding keys over generated module UUIDs.
- Migrate bindings for installed modules from UUID keys to namespace keys while preserving orphaned entries.
- Resolve LightBoard routing markers in the form `[lb-routing/<module namespace>]`.
- Accept a routing marker only when the request owner is the `lightboard` module, exactly one marker is present, and exactly one installed module matches the namespace.
- Fall back to the actual request owner when a marker is missing, unknown, or ambiguous.
- Expose LightBoard extension modules as selectable model-binding slots, including `lb-*` namespaces and legacy LightBoard module names.
- Add a `LightBoard Compatibility Mode` setting below the per-module binding master switch.
- Disable the compatibility setting while per-module model binding is disabled.
- Hide all LightBoard slots when compatibility mode is unchecked without deleting existing bindings.
- Add Korean, English, and Traditional Chinese labels.

## Compatibility and Safety

Normal chat messages cannot select a module preset through a routing marker because marker resolution requires a request already attributed to the `lightboard` module.

The existing per-module binding master switch remains off by default. The LightBoard compatibility option defaults to enabled to preserve the expanded slot list. Disabling it only controls slot visibility; saved bindings remain intact.

Non-LightBoard module discovery and routing behavior are unchanged.

## Verification

- Targeted Vitest suites: 55 passed
- `svelte-check`: 0 errors, 4 pre-existing accessibility warnings in `DefaultChatScreen.svelte`
- Production build: passed with pre-existing warnings
- `git diff --check`: passed
- Verification performed against the latest `develop` branch
