### PR TITLE
docs: add Google Play as a Termux source

### DIFF
--- a/docs/cn/termux.md
+++ b/docs/cn/termux.md
@@ -38,7 +38,7 @@ PocketRisu 不为 Termux 提供预编译的二进制文件,因此由手机自行
 
 - **F-Droid(推荐)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=zh-CN&pli=1
 
 
 ---

--- a/docs/cn/termux.md
+++ b/docs/cn/termux.md
@@ -8,7 +8,7 @@
 
 本指南介绍如何通过 Termux 在 Android 手机上直接构建并运行 PocketRisu。预期使用方式是在同一台手机的浏览器中打开 `http://localhost:6001`。
 
-- [1. 准备工作](#1-准备工作) — F-Droid Termux 与系统要求
+- [1. 准备工作](#1-准备工作) — Termux 与系统要求
 - [2. 安装与构建](#2-安装与构建) — 单条命令完成
 - [3. 运行与连接](#3-运行与连接) — 从手机浏览器打开
 - [4. 保持运行](#4-保持运行) — 屏幕关闭时也保持运行
@@ -32,17 +32,13 @@ PocketRisu 不为 Termux 提供预编译的二进制文件,因此由手机自行
 
 ## 1. 准备工作
 
-### 使用 F-Droid 或 GitHub Releases 版本的 Termux
-
-> ⚠️ **Play Store 版本的 Termux 无法使用。**
-> Termux 维护者已于 2020 年停止更新 Play Store 版本,无法再安装 PocketRisu 所需的最新软件包(Node.js 22+)。
+### 安装 Termux
 
 请从以下任一来源安装 Termux:
 
 - **F-Droid(推荐)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-
-如果已经安装了 Play Store 版本,请先卸载,然后从上述任一来源重新安装。
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
 
 
 ---

--- a/docs/de/termux.md
+++ b/docs/de/termux.md
@@ -8,7 +8,7 @@
 
 Diese Anleitung erklärt, wie PocketRisu direkt auf einem Android-Telefon über Termux gebaut und ausgeführt wird. Das vorgesehene Nutzungsmuster ist das Öffnen von `http://localhost:6001` im Browser desselben Telefons.
 
-- [1. Voraussetzungen](#1-voraussetzungen) — F-Droid Termux und Systemanforderungen
+- [1. Voraussetzungen](#1-voraussetzungen) — Termux und Systemanforderungen
 - [2. Installation und Build](#2-installation-und-build) — Einrichtung mit einem einzigen Befehl
 - [3. Ausführen und Verbinden](#3-ausführen-und-verbinden) — vom Browser des Telefons öffnen
 - [4. Laufen lassen](#4-laufen-lassen) — auch bei ausgeschaltetem Bildschirm
@@ -32,17 +32,13 @@ PocketRisu liefert keine vorkompilierten Binärdateien für Termux, daher baut d
 
 ## 1. Voraussetzungen
 
-### Verwenden Sie die F-Droid- oder GitHub-Releases-Version von Termux
-
-> ⚠️ **Die Play-Store-Version von Termux kann nicht verwendet werden.**
-> Die Termux-Maintainer haben die Aktualisierung der Play-Store-Version 2020 eingestellt, und sie kann die aktuellen Pakete, die PocketRisu benötigt (Node.js 22+), nicht mehr installieren.
+### Termux installieren
 
 Installieren Sie Termux von einer dieser Quellen:
 
 - **F-Droid (empfohlen)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-
-Wenn Sie bereits die Play-Store-Version installiert haben, deinstallieren Sie sie zuerst und installieren Sie aus einer der obigen Quellen.
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
 
 
 ---

--- a/docs/de/termux.md
+++ b/docs/de/termux.md
@@ -38,7 +38,7 @@ Installieren Sie Termux von einer dieser Quellen:
 
 - **F-Droid (empfohlen)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=de&pli=1
 
 
 ---

--- a/docs/en/termux.md
+++ b/docs/en/termux.md
@@ -6,7 +6,7 @@
 
 This guide explains how to build and run PocketRisu directly on an Android phone using Termux. The intended use pattern is to open `http://localhost:6001` in the phone's own browser.
 
-- [1. Prerequisites](#1-prerequisites) — F-Droid Termux and system requirements
+- [1. Prerequisites](#1-prerequisites) — Termux and system requirements
 - [2. Install and Build](#2-install-and-build) — single-command setup
 - [3. Run and Connect](#3-run-and-connect) — open from the phone's browser
 - [4. Keep It Running](#4-keep-it-running) — survive screen-off
@@ -30,17 +30,13 @@ PocketRisu does not ship pre-compiled binaries for Termux, so the phone builds e
 
 ## 1. Prerequisites
 
-### Use the F-Droid or GitHub Releases build of Termux
-
-> ⚠️ **The Play Store version of Termux cannot be used.**
-> The Termux maintainers stopped updating the Play Store build in 2020, and it can no longer install the recent packages PocketRisu needs (Node.js 22+).
+### Install Termux
 
 Install Termux from one of:
 
 - **F-Droid (recommended)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-
-If you already have the Play Store version installed, uninstall it first and install from one of the sources above.
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
 
 
 ---

--- a/docs/es/termux.md
+++ b/docs/es/termux.md
@@ -8,7 +8,7 @@
 
 Esta guía explica cómo compilar y ejecutar PocketRisu directamente en un teléfono Android usando Termux. El patrón de uso previsto es abrir `http://localhost:6001` en el navegador del propio teléfono.
 
-- [1. Requisitos previos](#1-requisitos-previos) — Termux de F-Droid y requisitos del sistema
+- [1. Requisitos previos](#1-requisitos-previos) — Termux y requisitos del sistema
 - [2. Instalación y compilación](#2-instalación-y-compilación) — configuración con un solo comando
 - [3. Ejecución y conexión](#3-ejecución-y-conexión) — abrir desde el navegador del teléfono
 - [4. Mantener en ejecución](#4-mantener-en-ejecución) — sobrevivir con la pantalla apagada
@@ -32,17 +32,13 @@ PocketRisu no proporciona binarios precompilados para Termux, por lo que el tel�
 
 ## 1. Requisitos previos
 
-### Utilice la versión de Termux de F-Droid o GitHub Releases
-
-> ⚠️ **La versión de Termux de Play Store no se puede utilizar.**
-> Los mantenedores de Termux dejaron de actualizar la versión de Play Store en 2020, y ya no puede instalar los paquetes recientes que PocketRisu necesita (Node.js 22+).
+### Instale Termux
 
 Instale Termux desde una de las siguientes fuentes:
 
 - **F-Droid (recomendado)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-
-Si ya tiene la versión de Play Store instalada, desinstálela primero e instálela desde una de las fuentes anteriores.
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
 
 
 ---

--- a/docs/es/termux.md
+++ b/docs/es/termux.md
@@ -38,7 +38,7 @@ Instale Termux desde una de las siguientes fuentes:
 
 - **F-Droid (recomendado)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=es&pli=1
 
 
 ---

--- a/docs/ko/termux.md
+++ b/docs/ko/termux.md
@@ -6,7 +6,7 @@
 
 안드로이드 폰에서 Termux를 통해 PocketRisu를 직접 빌드해 사용하는 방법을 안내합니다. 같은 폰의 브라우저에서 `http://localhost:6001`로 접속하는 사용 패턴이 기본입니다.
 
-- [1. 사전 준비](#1-사전-준비) — F-Droid Termux + 시스템 요구사항
+- [1. 사전 준비](#1-사전-준비) — Termux + 시스템 요구사항
 - [2. 설치 및 빌드](#2-설치-및-빌드) — 한 줄 명령으로 자동 진행
 - [3. 실행 및 접속](#3-실행-및-접속) — 폰 브라우저로 사용
 - [4. 백그라운드 유지](#4-백그라운드-유지) — 화면 꺼진 상태에서도 서버 유지
@@ -30,17 +30,13 @@ PocketRisu는 Termux에서 미리 컴파일된 바이너리를 제공하지 않�
 
 ## 1. 사전 준비
 
-### Termux는 F-Droid 또는 GitHub Releases 버전을 사용
+### Termux 설치
 
-> ⚠️ **Play Store의 Termux는 사용할 수 없습니다.**
-> Termux 개발진이 2020년 이후 Play Store 버전 업데이트를 중단했으며, PocketRisu 빌드에 필요한 최신 패키지(Node.js 22 이상 등)가 설치되지 않습니다.
-
-다음 두 곳 중 하나에서 Termux를 받습니다.
+다음 중 한 곳에서 Termux를 받습니다.
 
 - **F-Droid (권장)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-
-이미 Play Store 버전이 설치돼 있다면 삭제 후 위 두 곳 중 한 곳에서 새로 설치합니다.
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
 
 
 ---

--- a/docs/ko/termux.md
+++ b/docs/ko/termux.md
@@ -36,7 +36,7 @@ PocketRisu는 Termux에서 미리 컴파일된 바이너리를 제공하지 않�
 
 - **F-Droid (권장)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=ko&pli=1
 
 
 ---

--- a/docs/vi/termux.md
+++ b/docs/vi/termux.md
@@ -8,7 +8,7 @@
 
 Hướng dẫn này giải thích cách xây dựng và chạy PocketRisu trực tiếp trên điện thoại Android sử dụng Termux. Mẫu sử dụng dự kiến là mở `http://localhost:6001` trong trình duyệt của chính điện thoại.
 
-- [1. Điều kiện tiên quyết](#1-điều-kiện-tiên-quyết) — Termux từ F-Droid và yêu cầu hệ thống
+- [1. Điều kiện tiên quyết](#1-điều-kiện-tiên-quyết) — Termux và yêu cầu hệ thống
 - [2. Cài đặt và xây dựng](#2-cài-đặt-và-xây-dựng) — thiết lập bằng một lệnh duy nhất
 - [3. Chạy và kết nối](#3-chạy-và-kết-nối) — mở từ trình duyệt điện thoại
 - [4. Duy trì hoạt động](#4-duy-trì-hoạt-động) — tiếp tục chạy khi tắt màn hình
@@ -32,17 +32,13 @@ PocketRisu không cung cấp tệp nhị phân biên dịch sẵn cho Termux, v�
 
 ## 1. Điều kiện tiên quyết
 
-### Sử dụng phiên bản Termux từ F-Droid hoặc GitHub Releases
-
-> ⚠️ **Không thể sử dụng phiên bản Termux trên Play Store.**
-> Các bảo trì viên Termux đã ngừng cập nhật bản Play Store vào năm 2020, và bản này không còn cài đặt được các gói mới mà PocketRisu cần (Node.js 22+).
+### Cài đặt Termux
 
 Cài đặt Termux từ một trong các nguồn sau:
 
 - **F-Droid (khuyến nghị)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-
-Nếu bạn đã cài bản từ Play Store, hãy gỡ cài đặt trước rồi cài lại từ một trong các nguồn trên.
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
 
 
 ---

--- a/docs/vi/termux.md
+++ b/docs/vi/termux.md
@@ -38,7 +38,7 @@ Cài đặt Termux từ một trong các nguồn sau:
 
 - **F-Droid (khuyến nghị)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=vi&pli=1
 
 
 ---

--- a/docs/zh-Hant/termux.md
+++ b/docs/zh-Hant/termux.md
@@ -8,7 +8,7 @@
 
 本指南介紹如何透過 Termux 在 Android 手機上直接建置並執行 PocketRisu。預期使用方式是在同一支手機的瀏覽器中開啟 `http://localhost:6001`。
 
-- [1. 準備工作](#1-準備工作) — F-Droid Termux 與系統需求
+- [1. 準備工作](#1-準備工作) — Termux 與系統需求
 - [2. 安裝與建置](#2-安裝與建置) — 一條命令完成
 - [3. 執行與連線](#3-執行與連線) — 從手機瀏覽器開啟
 - [4. 保持執行](#4-保持執行) — 螢幕關閉時也保持執行
@@ -32,17 +32,13 @@ PocketRisu 不為 Termux 提供預先編譯的二進位檔,因此由手機自行
 
 ## 1. 準備工作
 
-### 使用 F-Droid 或 GitHub Releases 版本的 Termux
-
-> ⚠️ **Play Store 版本的 Termux 無法使用。**
-> Termux 維護者已於 2020 年停止更新 Play Store 版本,無法再安裝 PocketRisu 所需的最新套件(Node.js 22+)。
+### 安裝 Termux
 
 請從以下任一來源安裝 Termux:
 
 - **F-Droid(建議)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-
-如果已經安裝了 Play Store 版本,請先解除安裝,然後從上述任一來源重新安裝。
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
 
 
 ---

--- a/docs/zh-Hant/termux.md
+++ b/docs/zh-Hant/termux.md
@@ -38,7 +38,7 @@ PocketRisu 不為 Termux 提供預先編譯的二進位檔,因此由手機自行
 
 - **F-Droid(建議)**: https://f-droid.org/packages/com.termux/
 - **GitHub Releases**: https://github.com/termux/termux-app/releases
-- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=en&pli=1
+- **Google Play**: https://play.google.com/store/apps/details?id=com.termux&hl=zh-TW&pli=1
 
 
 ---


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions? (Not applicable: documentation-only change.)
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [ ] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models / providers?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?
       - We currently do not accept highly AI generated PRs that are large changes.


[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Add the current Google Play version of Termux as a supported installation source.

## Related Issues

None.

## Changes

- Removed obsolete warnings that the Google Play version of Termux cannot be used.
- Added the verified Google Play listing to the installation sources.
- Updated all seven localized Termux guides consistently.

## Impact

Users can install PocketRisu inside Termux build from Google Play without being incorrectly instructed to uninstall it. This is a documentation-only change with no runtime impact.

## Additional Notes

<img width="1004" height="327" alt="image" src="https://github.com/user-attachments/assets/1d428410-125b-4197-87a6-b2d00fbc151f" />

<img width="464" height="50" alt="image" src="https://github.com/user-attachments/assets/4dc6d124-9572-429d-b7a9-c4e9104e7d99" />

<img width="1076" height="370" alt="image" src="https://github.com/user-attachments/assets/c4a60028-29b2-44fd-8885-6334e0338618" />

Currently, Google play termux has deployed with latest stable release.
Tested build and run. It performs correctly, including disabling cloudflare tunnel feature.